### PR TITLE
fix(normalizers): cast baseMVA to float32 to support MPS backend

### DIFF
--- a/gridfm_graphkit/datasets/normalizers.py
+++ b/gridfm_graphkit/datasets/normalizers.py
@@ -228,7 +228,7 @@ class HeteroDataMVANormalizer(Normalizer):
         data.edge_attr_dict[("bus", "connects", "bus")][:, ANG_MIN] *= torch.pi / 180.0
         data.edge_attr_dict[("bus", "connects", "bus")][:, ANG_MAX] *= torch.pi / 180.0
         data.edge_attr_dict[("bus", "connects", "bus")][:, RATE_A] /= self.baseMVA
-        data.baseMVA = self.baseMVA
+        data.baseMVA = torch.tensor(self.baseMVA, dtype=torch.float32)
         data.is_normalized = True
 
     def inverse_transform(self, data: HeteroData):


### PR DESCRIPTION
The MPS (Apple Silicon) backend for PyTorch does not support float64. This PR ensures baseMVA is cast to float32 in the normalizer to prevent crashes on Mac GPUs.