### PR TITLE
fix: use DDPStrategy(find_unused_parameters=True)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CUDA_HOME=/usr/local/cuda \
     PATH="/usr/local/cuda/bin:${PATH}" \
     LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}" \
-    HOME=/app
+    HOME=/app \
+    OMP_NUM_THREADS=1 \
+    OPENBLAS_NUM_THREADS=1 \
+    MKL_NUM_THREADS=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         software-properties-common \

--- a/gridfm_graphkit/cli.py
+++ b/gridfm_graphkit/cli.py
@@ -19,6 +19,7 @@ from gridfm_graphkit.tasks.compute_ac_dc_metrics import compute_ac_dc_metrics
 from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 from lightning.pytorch.callbacks.model_checkpoint import ModelCheckpoint
 from lightning.pytorch.loggers import MLFlowLogger
+from lightning.pytorch.strategies import DDPStrategy
 import lightning as L
 
 
@@ -197,11 +198,15 @@ def main_cli(args):
     if epoch_timer is not None:
         training_callbacks = training_callbacks + [epoch_timer]
 
+    _strategy = config_args.training.strategy
+    if isinstance(_strategy, str) and _strategy in ("auto", "ddp", "ddp_find_unused_parameters_true"):
+        _strategy = DDPStrategy(find_unused_parameters=True)
+
     trainer = L.Trainer(
         logger=logger,
         accelerator=config_args.training.accelerator,
         devices=config_args.training.devices,
-        strategy=config_args.training.strategy,
+        strategy=_strategy,
         log_every_n_steps=1000,
         default_root_dir=args.log_dir,
         max_epochs=config_args.training.epochs,

--- a/gridfm_graphkit/cli.py
+++ b/gridfm_graphkit/cli.py
@@ -199,7 +199,11 @@ def main_cli(args):
         training_callbacks = training_callbacks + [epoch_timer]
 
     _strategy = config_args.training.strategy
-    if isinstance(_strategy, str) and _strategy in ("auto", "ddp", "ddp_find_unused_parameters_true"):
+    if isinstance(_strategy, str) and _strategy in (
+        "auto",
+        "ddp",
+        "ddp_find_unused_parameters_true",
+    ):
         _strategy = DDPStrategy(find_unused_parameters=True)
 
     trainer = L.Trainer(

--- a/gridfm_graphkit/datasets/hetero_powergrid_datamodule.py
+++ b/gridfm_graphkit/datasets/hetero_powergrid_datamodule.py
@@ -369,11 +369,12 @@ class LitGridHeteroDataModule(L.LightningDataModule):
             pin_memory=torch.cuda.is_available(),
             persistent_workers=num_workers > 0,
         )
-        # On Linux some HPC environments restrict passing open file descriptors
-        # via Unix socket ancillary data (SCM_RIGHTS), which causes
-        # "received 0 items of ancdata" with the default 'fork' start method.
-        # 'forkserver' avoids fd-passing by having a dedicated server process
-        # that re-opens shared memory objects by name instead.
+        # Use 'fork' on Linux. It avoids the forkserver intermediary pipe which
+        # is fragile when the process has many threads (e.g. OpenBLAS). In
+        # container environments (Kubernetes) fork works correctly. On
+        # traditional HPC systems with strict fd-passing restrictions the
+        # original 'forkserver' may be needed, but the pipe truncation it
+        # produces under thread pressure is worse than the ancdata warning.
         if (
             num_workers > 0
             and torch.multiprocessing.get_start_method(allow_none=True) != "spawn"
@@ -381,7 +382,7 @@ class LitGridHeteroDataModule(L.LightningDataModule):
             import platform
 
             if platform.system() == "Linux":
-                kwargs["multiprocessing_context"] = "forkserver"
+                kwargs["multiprocessing_context"] = "fork"
         return kwargs
 
     def train_dataloader(self):


### PR DESCRIPTION
- limits the number of threads used by OpenMP, OpenBLAS, and MKL libraries by setting `OMP_NUM_THREADS=1`, `OPENBLAS_NUM_THREADS=1`, and `MKL_NUM_THREADS=1` in the Docker environment to prevent thread oversubscription and improve stability in containerized environments.

- changes the multiprocessing start method from `'forkserver'` to `'fork'` 

 - explicitly uses `DDPStrategy(find_unused_parameters=True)` for improved compatibility.