### PR TITLE
Fix opf res with inactive gen branch

### DIFF
--- a/gridfm_graphkit/tasks/opf_ac_dc_baseline.py
+++ b/gridfm_graphkit/tasks/opf_ac_dc_baseline.py
@@ -48,11 +48,15 @@ def _load_test_data(data_dir: str, test_scenario_ids: list[int]):
         os.path.join(data_dir, "gen_data.parquet"),
         filters=partition_filter,
     )
+    # drop where in_service is 0 so the means are computed over the same number of gens as for the model in opf_task
+    gen_df = gen_df[gen_df["in_service"] == 1].reset_index(drop=True)
     branch_df = pd.read_parquet(
         os.path.join(data_dir, "branch_data.parquet"),
         filters=partition_filter,
     )
     branch_df = branch_df.drop(columns=["pf_dc", "pt_dc"], axis=1)
+    # drop where br_status is 0 so the means are computed over the same number of branches as for the model in opf_task
+    branch_df = branch_df[branch_df["br_status"] == 1].reset_index(drop=True)
     runtime_df = pd.read_parquet(
         os.path.join(data_dir, "runtime_data.parquet"),
         filters=partition_filter,
@@ -81,8 +85,8 @@ def _compute_optimality_gap(gen_df: pd.DataFrame) -> dict:
     pg_ac = gen_df["p_mw"].to_numpy(dtype=float)
     pg_dc = gen_df["p_mw_dc"].to_numpy(dtype=float)
     g = gen_df.copy()
-    g["cost_ac"] = c0 + c1 * pg_ac + c2 * pg_ac * pg_ac # all is already in MW
-    g["cost_dc"] = c0 + c1 * pg_dc + c2 * pg_dc * pg_dc # all is already in MW
+    g["cost_ac"] = (c0 + c1 * pg_ac + c2 * pg_ac * pg_ac) * g["in_service"] # all is already in MW
+    g["cost_dc"] = (c0 + c1 * pg_dc + c2 * pg_dc * pg_dc) * g["in_service"] # all is already in MW
     per_scenario = g.groupby("scenario")[["cost_ac", "cost_dc"]].sum()
     cost_ac = per_scenario["cost_ac"].to_numpy(dtype=float)
     cost_dc = per_scenario["cost_dc"].to_numpy(dtype=float)
@@ -143,8 +147,8 @@ def _compute_branch_violations(branch_df: pd.DataFrame, bus_df: pd.DataFrame) ->
     ac_to = np.sqrt(
         branch_df["pt"].to_numpy(dtype=float) ** 2 + branch_df["qt"].to_numpy(dtype=float) ** 2,
     )
-    dc_from = np.abs(branch_df["pf_dc_computed"].to_numpy(dtype=float))
-    dc_to = np.abs(branch_df["pt_dc_computed"].to_numpy(dtype=float))
+    dc_from = np.sqrt(branch_df["pf_dc_computed"].to_numpy(dtype=float) ** 2 + branch_df["qf_dc_computed"].to_numpy(dtype=float) ** 2) # reactive part is needed here
+    dc_to = np.sqrt(branch_df["pt_dc_computed"].to_numpy(dtype=float) ** 2 + branch_df["qt_dc_computed"].to_numpy(dtype=float) ** 2)
 
     ac_thermal_from = np.maximum(ac_from - rate, 0.0)
     ac_thermal_to = np.maximum(ac_to - rate, 0.0)
@@ -231,7 +235,7 @@ def compute_opf_ac_dc_metrics(
     ac_stats = _compute_residual_stats(balance_ac, dc=False)
 
     print("  Computing DC power balance...")
-    pf_dc, _, pt_dc, _ = compute_branch_powers_vectorized(
+    pf_dc, qf_dc, pt_dc, qt_dc = compute_branch_powers_vectorized(
         branch_df,
         bus_df,
         dc=True,
@@ -252,6 +256,8 @@ def compute_opf_ac_dc_metrics(
     branch_df = branch_df.copy()
     branch_df["pf_dc_computed"] = pf_dc
     branch_df["pt_dc_computed"] = pt_dc
+    branch_df["qf_dc_computed"] = qf_dc
+    branch_df["qt_dc_computed"] = qt_dc
     
 
     opf_extra = {}

--- a/gridfm_graphkit/tasks/opf_task.py
+++ b/gridfm_graphkit/tasks/opf_task.py
@@ -87,14 +87,14 @@ class OptimalPowerFlowTask(ReconstructionTask):
         c2 = batch.x_dict["gen"][:, C2_H]
         target_pg = batch.y_dict["gen"].squeeze()
         pred_pg = output["gen"].squeeze()
-        gen_cost_gt = c0 + c1 * target_pg + c2 * target_pg**2
-        gen_cost_pred = c0 + c1 * pred_pg + c2 * pred_pg**2
+        gen_cost_gt = (c0 + c1 * target_pg + c2 * target_pg**2) # assumes all branches are on!
+        gen_cost_pred = (c0 + c1 * pred_pg + c2 * pred_pg**2) # assumes all branches are on!
 
         gen_batch = batch.batch_dict["gen"]  # shape: [N_gen_total]
 
         cost_gt = scatter_add(gen_cost_gt, gen_batch, dim=0)
         cost_pred = scatter_add(gen_cost_pred, gen_batch, dim=0)
-
+        
         optimality_gap = torch.mean(torch.abs((cost_pred - cost_gt) / cost_gt * 100))
 
         agg_gen_on_bus = scatter_add(


### PR DESCRIPTION
## Summary
- Filter inactive generators and branches before computing OPF baseline metrics (otherwise, the denominator is larger than it should be)
- Include reactive branch flows when checking thermal violations obtained using DC solutions to PF
- Clarify OPF metric assumptions around active branches/generators in the data

