### PR TITLE
Add optional embedding export in predict

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -185,6 +185,7 @@ jobs:
           # PYSEC-2025-206, PYSEC-2025-204, PYSEC-2025-203: torch 2.8.0 issues, fixed in 2.9.0
           # PYSEC-2026-139: torch pt2 deserialization, local-only, no fix released yet
           # CVE-2025-2999, CVE-2025-3000, CVE-2025-3001: torch 2.8.0 memory corruption bugs (local execution vector)
+          # CVE-2026-69247: cryptography PKCS#7 EnvelopedData Bleichenbacher oracle; not reachable, this repo never does PKCS#7/S-MIME decryption
           ignore-vulns: |
             CVE-2026-4539
             PYSEC-2025-206
@@ -194,6 +195,7 @@ jobs:
             CVE-2025-2999
             CVE-2025-3000
             CVE-2025-3001
+            CVE-2026-69247
 
   trivy_repo:
       name: Trivy (repo scan)

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ gridfm_graphkit predict --config path/to/config.yaml --model_path path/to/model.
 | `--num_workers` | `int` | Override `data.workers` from YAML. Use `0` to debug worker crashes. | `None` |
 | `--dataset_wrapper_cache_dir` | `str` | Disk cache directory for dataset wrapper; cache is loaded from here when present and saved after first population. | `None` |
 | `--output_path` | `str` | Directory where predictions are saved as `<grid_name>_predictions.parquet`. | `data` |
-| `--get-embeddings` | `flag` | Export final hidden embeddings as separate parquet files during prediction. | `False` |
+| `--get_embeddings` | `flag` | Export final hidden embeddings to `<grid_name>_bus_embeddings.parquet` (and `<grid_name>_gen_embeddings.parquet` for OPF models that expose gen embeddings) in `--output_path`. | `False` |
 | `--compile [MODE]` | `str` | Enable `torch.compile` mode. Valid values: `default`, `reduce-overhead`, `max-autotune`, `max-autotune-no-cudagraphs`. If flag is passed without a value, mode is `default`. | `None` |
 | `--bfloat16` | `flag` | Cast model to `torch.bfloat16` (`model.to(torch.bfloat16)`). | `False` |
 | `--tf32` | `flag` | Enable TF32 on Ampere+ GPUs via `torch.set_float32_matmul_precision("high")`. | `False` |

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ gridfm_graphkit predict --config path/to/config.yaml --model_path path/to/model.
 | `--num_workers` | `int` | Override `data.workers` from YAML. Use `0` to debug worker crashes. | `None` |
 | `--dataset_wrapper_cache_dir` | `str` | Disk cache directory for dataset wrapper; cache is loaded from here when present and saved after first population. | `None` |
 | `--output_path` | `str` | Directory where predictions are saved as `<grid_name>_predictions.parquet`. | `data` |
+| `--get-embeddings` | `flag` | Export final hidden embeddings as separate parquet files during prediction. | `False` |
 | `--compile [MODE]` | `str` | Enable `torch.compile` mode. Valid values: `default`, `reduce-overhead`, `max-autotune`, `max-autotune-no-cudagraphs`. If flag is passed without a value, mode is `default`. | `None` |
 | `--bfloat16` | `flag` | Cast model to `torch.bfloat16` (`model.to(torch.bfloat16)`). | `False` |
 | `--tf32` | `flag` | Enable TF32 on Ampere+ GPUs via `torch.set_float32_matmul_precision("high")`. | `False` |

--- a/docs/quick_start/quick_start.md
+++ b/docs/quick_start/quick_start.md
@@ -149,6 +149,7 @@ gridfm_graphkit predict --config path/to/config.yaml --model_path path/to/model.
 | `--num_workers` | `int` | Override `data.workers` from YAML. Use `0` to debug worker crashes. | `None` |
 | `--dataset_wrapper_cache_dir` | `str` | Disk cache directory for dataset wrapper; cache is loaded from here when present and saved after first population. | `None` |
 | `--output_path` | `str` | Directory where predictions are saved as `<grid_name>_predictions.parquet`. | `data` |
+| `--get-embeddings` | `flag` | Export final hidden embeddings as separate parquet files during prediction. | `False` |
 | `--compile [MODE]` | `str` | Enable `torch.compile` mode. Valid values: `default`, `reduce-overhead`, `max-autotune`, `max-autotune-no-cudagraphs`. If flag is passed without a value, mode is `default`. | `None` |
 | `--bfloat16` | `flag` | Cast model to `torch.bfloat16` (`model.to(torch.bfloat16)`). | `False` |
 | `--tf32` | `flag` | Enable TF32 on Ampere+ GPUs via `torch.set_float32_matmul_precision("high")`. | `False` |

--- a/docs/quick_start/quick_start.md
+++ b/docs/quick_start/quick_start.md
@@ -149,7 +149,7 @@ gridfm_graphkit predict --config path/to/config.yaml --model_path path/to/model.
 | `--num_workers` | `int` | Override `data.workers` from YAML. Use `0` to debug worker crashes. | `None` |
 | `--dataset_wrapper_cache_dir` | `str` | Disk cache directory for dataset wrapper; cache is loaded from here when present and saved after first population. | `None` |
 | `--output_path` | `str` | Directory where predictions are saved as `<grid_name>_predictions.parquet`. | `data` |
-| `--get-embeddings` | `flag` | Export final hidden embeddings as separate parquet files during prediction. | `False` |
+| `--get_embeddings` | `flag` | Export final hidden embeddings to `<grid_name>_bus_embeddings.parquet` (and `<grid_name>_gen_embeddings.parquet` for OPF models that expose gen embeddings) in `--output_path`. | `False` |
 | `--compile [MODE]` | `str` | Enable `torch.compile` mode. Valid values: `default`, `reduce-overhead`, `max-autotune`, `max-autotune-no-cudagraphs`. If flag is passed without a value, mode is `default`. | `None` |
 | `--bfloat16` | `flag` | Cast model to `torch.bfloat16` (`model.to(torch.bfloat16)`). | `False` |
 | `--tf32` | `flag` | Enable TF32 on Ampere+ GPUs via `torch.set_float32_matmul_precision("high")`. | `False` |

--- a/gridfm_graphkit/__main__.py
+++ b/gridfm_graphkit/__main__.py
@@ -371,6 +371,11 @@ def main():
         help="Directory for the dataset wrapper's disk cache. If set, cache is loaded from here when present and saved here after first population.",
     )
     predict_parser.add_argument("--output_path", type=str, default="data")
+    predict_parser.add_argument(
+        "--get-embeddings",
+        action="store_true",
+        help="Export final hidden embeddings as separate parquet files during predict.",
+    )
     predict_parser.add_argument("--compile", **_compile_kwargs)
     predict_parser.add_argument("--bfloat16", **_bfloat16_kwargs)
     predict_parser.add_argument("--tf32", **_tf32_kwargs)

--- a/gridfm_graphkit/__main__.py
+++ b/gridfm_graphkit/__main__.py
@@ -372,7 +372,7 @@ def main():
     )
     predict_parser.add_argument("--output_path", type=str, default="data")
     predict_parser.add_argument(
-        "--get-embeddings",
+        "--get_embeddings",
         action="store_true",
         help="Export final hidden embeddings as separate parquet files during predict.",
     )

--- a/gridfm_graphkit/cli.py
+++ b/gridfm_graphkit/cli.py
@@ -60,6 +60,20 @@ def _predictions_to_dataframe(predictions: list[dict[str, np.ndarray]]) -> pd.Da
     return pd.DataFrame({key: np.concatenate(vals) for key, vals in rows.items()})
 
 
+def _prediction_output_filename(grid_name: str, table_name: str) -> str:
+    """Return the parquet filename for one prediction or embedding table."""
+
+    if table_name == "bus":
+        return f"{grid_name}_predictions.parquet"
+    if table_name == "gen":
+        return f"{grid_name}_gen_predictions.parquet"
+    if table_name == "bus_embeddings":
+        return f"{grid_name}_bus_embeddings.parquet"
+    if table_name == "gen_embeddings":
+        return f"{grid_name}_gen_embeddings.parquet"
+    return f"{grid_name}_{table_name}_predictions.parquet"
+
+
 def _validate_dataset_wrapper(name: str | None) -> None:
     """Raise a helpful error if *name* is not registered in DATASET_WRAPPER_REGISTRY."""
     if name is None:
@@ -79,6 +93,7 @@ def benchmark_cli(args):
         base_config = yaml.safe_load(f)
 
     config_args = NestedNamespace(**base_config)
+    config_args.get_embeddings = bool(getattr(args, "get_embeddings", False))
 
     num_workers_override = getattr(args, "num_workers", None)
     if num_workers_override is not None:
@@ -187,6 +202,7 @@ def main_cli(args):
         base_config = yaml.safe_load(f)
 
     config_args = NestedNamespace(**base_config)
+    config_args.get_embeddings = bool(getattr(args, "get_embeddings", False))
 
     L.seed_everything(config_args.seed, workers=True)
 
@@ -410,10 +426,9 @@ def main_cli(args):
                 df = _predictions_to_dataframe(
                     [batch[table_name] for batch in predictions],
                 )
-                suffix = "" if table_name == "bus" else f"_{table_name}"
                 out_path = os.path.join(
                     output_dir,
-                    f"{grid_name}{suffix}_predictions.parquet",
+                    _prediction_output_filename(grid_name, table_name),
                 )
                 df.to_parquet(out_path, index=False)
                 print(f"Saved {table_name} predictions to {out_path}")

--- a/gridfm_graphkit/cli.py
+++ b/gridfm_graphkit/cli.py
@@ -93,7 +93,6 @@ def benchmark_cli(args):
         base_config = yaml.safe_load(f)
 
     config_args = NestedNamespace(**base_config)
-    config_args.get_embeddings = bool(getattr(args, "get_embeddings", False))
 
     num_workers_override = getattr(args, "num_workers", None)
     if num_workers_override is not None:

--- a/gridfm_graphkit/models/gnn_heterogeneous_gns.py
+++ b/gridfm_graphkit/models/gnn_heterogeneous_gns.py
@@ -171,6 +171,14 @@ class GNS_heterogeneous(nn.Module):
             edge_index_dict: keys like ("bus","connects","bus"), ("gen","connected_to","bus"), ("bus","connected_to","gen")
             edge_attr_dict: same keys -> edge attributes (bus-bus requires G,B)
             mask_dict: dict mapping node/bus types to mask tensors
+
+        When ``return_embeddings`` is ``True``, returns ``(predictions, embeddings)``
+        instead of ``predictions`` alone. Each embedding is the latent tensor fed
+        directly into the corresponding prediction head: ``embeddings["bus"]`` is
+        the ``h_bus`` consumed by ``mlp_bus`` and ``embeddings["gen"]`` is the
+        ``h_gen`` consumed by ``mlp_gen`` on the final layer. (Note the last-layer
+        ``physics_mlp`` update to ``h_bus`` is intentionally skipped, so the
+        returned bus embedding is exactly the head input, not a post-update state.)
         """
         x_dict = batch.x_dict
         edge_index_dict = batch.edge_index_dict

--- a/gridfm_graphkit/models/gnn_heterogeneous_gns.py
+++ b/gridfm_graphkit/models/gnn_heterogeneous_gns.py
@@ -162,7 +162,7 @@ class GNS_heterogeneous(nn.Module):
         # container for monitoring residual norms per layer and type
         self.layer_residuals = {}
 
-    def forward(self, batch):
+    def forward(self, batch, return_embeddings: bool = False):
         """
         Accepts a PyG HeteroData batch and extracts the required tensors.
 
@@ -300,4 +300,7 @@ class GNS_heterogeneous(nn.Module):
                 ).mean()
                 h_bus = h_bus + self.physics_mlp(bus_residuals)
 
-        return {"bus": output_temp, "gen": gen_temp}
+        predictions = {"bus": output_temp, "gen": gen_temp}
+        if not return_embeddings:
+            return predictions
+        return predictions, {"bus": h_bus, "gen": h_gen}

--- a/gridfm_graphkit/models/gnn_heterogeneous_gns.py
+++ b/gridfm_graphkit/models/gnn_heterogeneous_gns.py
@@ -221,6 +221,10 @@ class GNS_heterogeneous(nn.Module):
             bus_temp = self.mlp_bus(h_bus)  # [Nb, 2]  -> Vm, Va
             gen_temp = self.mlp_gen(h_gen)  # [Ng, 1]  -> Pg
 
+            # Snapshot the embedding that actually produced bus_temp/output_temp,
+            # before the physics-residual update below moves h_bus past it.
+            h_bus_embed = h_bus
+
             if self.task == "StateEstimation":
                 if i == self.num_layers - 1:
                     Pft, Qft = self.branch_flow_layer(
@@ -303,4 +307,4 @@ class GNS_heterogeneous(nn.Module):
         predictions = {"bus": output_temp, "gen": gen_temp}
         if not return_embeddings:
             return predictions
-        return predictions, {"bus": h_bus, "gen": h_gen}
+        return predictions, {"bus": h_bus_embed, "gen": h_gen}

--- a/gridfm_graphkit/models/gnn_heterogeneous_gns.py
+++ b/gridfm_graphkit/models/gnn_heterogeneous_gns.py
@@ -221,13 +221,6 @@ class GNS_heterogeneous(nn.Module):
             bus_temp = self.mlp_bus(h_bus)  # [Nb, 2]  -> Vm, Va
             gen_temp = self.mlp_gen(h_gen)  # [Ng, 1]  -> Pg
 
-            # Snapshot the embedding that actually produced bus_temp/output_temp.
-            # The physics-residual update below rebinds h_bus out-of-place, so a
-            # plain reference is already correct; clone() keeps it correct if that
-            # ever becomes an in-place update.
-            if return_embeddings:
-                h_bus_embed = h_bus.clone()
-
             if self.task == "StateEstimation":
                 if i == self.num_layers - 1:
                     Pft, Qft = self.branch_flow_layer(
@@ -300,14 +293,22 @@ class GNS_heterogeneous(nn.Module):
 
                 bus_residuals = torch.stack([residual_P, residual_Q], dim=-1)
 
-                # Save and project residuals to latent space
+                # Save and project residuals to latent space.
+                # layer_residuals is consumed by LayeredWeightedPhysicsLoss for
+                # every layer, so it is recorded unconditionally.
                 self.layer_residuals[i] = torch.linalg.norm(
                     bus_residuals,
                     dim=-1,
                 ).mean()
-                h_bus = h_bus + self.physics_mlp(bus_residuals)
+                # On the last layer the updated h_bus is never read again: the
+                # loop ends, predictions come from output_temp/gen_temp, and the
+                # exported embedding is the tensor that fed mlp_bus. Skipping the
+                # update avoids a dead forward pass and makes h_bus itself the
+                # correct embedding to return (no snapshot/clone needed).
+                if i < self.num_layers - 1:
+                    h_bus = h_bus + self.physics_mlp(bus_residuals)
 
         predictions = {"bus": output_temp, "gen": gen_temp}
         if not return_embeddings:
             return predictions
-        return predictions, {"bus": h_bus_embed, "gen": h_gen}
+        return predictions, {"bus": h_bus, "gen": h_gen}

--- a/gridfm_graphkit/models/gnn_heterogeneous_gns.py
+++ b/gridfm_graphkit/models/gnn_heterogeneous_gns.py
@@ -221,9 +221,12 @@ class GNS_heterogeneous(nn.Module):
             bus_temp = self.mlp_bus(h_bus)  # [Nb, 2]  -> Vm, Va
             gen_temp = self.mlp_gen(h_gen)  # [Ng, 1]  -> Pg
 
-            # Snapshot the embedding that actually produced bus_temp/output_temp,
-            # before the physics-residual update below moves h_bus past it.
-            h_bus_embed = h_bus
+            # Snapshot the embedding that actually produced bus_temp/output_temp.
+            # The physics-residual update below rebinds h_bus out-of-place, so a
+            # plain reference is already correct; clone() keeps it correct if that
+            # ever becomes an in-place update.
+            if return_embeddings:
+                h_bus_embed = h_bus.clone()
 
             if self.task == "StateEstimation":
                 if i == self.num_layers - 1:

--- a/gridfm_graphkit/models/grit_transformer.py
+++ b/gridfm_graphkit/models/grit_transformer.py
@@ -385,7 +385,10 @@ class GritHeteroAdapter(torch.nn.Module):
         Returns:
             dict with keys ``"bus"`` and ``"gen"``, each mapping to the
             predicted output features. When ``return_embeddings`` is ``True``,
-            also returns a ``{"bus": ...}`` embedding dictionary.
+            also returns a ``{"bus": ...}`` embedding dictionary, where the bus
+            embedding is the latent tensor (``homo.x``) fed into the prediction
+            heads. This model does not expose a separate ``"gen"`` embedding, so
+            downstream gen-embedding export is skipped for GRIT.
         """
         # --- Extract bus-only homogeneous subgraph ---
         # Aggregate generator PG onto buses

--- a/gridfm_graphkit/models/grit_transformer.py
+++ b/gridfm_graphkit/models/grit_transformer.py
@@ -375,7 +375,7 @@ class GritHeteroAdapter(torch.nn.Module):
         else:
             self.gen_head = None
 
-    def forward(self, batch):
+    def forward(self, batch, return_embeddings: bool = False):
         """Forward pass on a heterogeneous power-grid batch.
 
         Args:
@@ -384,7 +384,8 @@ class GritHeteroAdapter(torch.nn.Module):
 
         Returns:
             dict with keys ``"bus"`` and ``"gen"``, each mapping to the
-            predicted output features.
+            predicted output features. When ``return_embeddings`` is ``True``,
+            also returns a ``{"bus": ...}`` embedding dictionary.
         """
         # --- Extract bus-only homogeneous subgraph ---
         # Aggregate generator PG onto buses
@@ -428,4 +429,7 @@ class GritHeteroAdapter(torch.nn.Module):
             else batch["gen"].x
         )
 
-        return {"bus": bus_out, "gen": gen_out}
+        predictions = {"bus": bus_out, "gen": gen_out}
+        if not return_embeddings:
+            return predictions
+        return predictions, {"bus": homo.x}

--- a/gridfm_graphkit/tasks/opf_task.py
+++ b/gridfm_graphkit/tasks/opf_task.py
@@ -531,11 +531,12 @@ class OptimalPowerFlowTask(ReconstructionTask):
         self.test_outputs.clear()
 
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
-        embeddings = None
+        # Predict only needs the forward pass; shared_step would also compute a
+        # loss that is discarded here (and would require targets to be present).
         if getattr(self.args, "get_embeddings", False):
             output, embeddings = self.model(batch, return_embeddings=True)
         else:
-            output, _ = self.shared_step(batch)
+            output, embeddings = self.model(batch), None
 
         self.data_normalizers[dataloader_idx].inverse_transform(batch)
         self.data_normalizers[dataloader_idx].inverse_output(output, batch)

--- a/gridfm_graphkit/tasks/opf_task.py
+++ b/gridfm_graphkit/tasks/opf_task.py
@@ -30,6 +30,8 @@ from gridfm_graphkit.datasets.globals import (
 from gridfm_graphkit.tasks.reconstruction_tasks import ReconstructionTask
 from gridfm_graphkit.io.registries import TASK_REGISTRY
 from gridfm_graphkit.tasks.utils import (
+    embedding_table_from_tensor,
+    local_index_per_graph,
     plot_correlation_by_node_type,
     plot_residuals_histograms,
     residual_stats_by_type,
@@ -529,7 +531,11 @@ class OptimalPowerFlowTask(ReconstructionTask):
         self.test_outputs.clear()
 
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
-        output, _ = self.shared_step(batch)
+        embeddings = None
+        if getattr(self.args, "get_embeddings", False):
+            output, embeddings = self.model(batch, return_embeddings=True)
+        else:
+            output, _ = self.shared_step(batch)
 
         self.data_normalizers[dataloader_idx].inverse_transform(batch)
         self.data_normalizers[dataloader_idx].inverse_output(output, batch)
@@ -556,12 +562,8 @@ class OptimalPowerFlowTask(ReconstructionTask):
 
         bus_batch = batch.batch_dict["bus"]
         scenario_ids = batch["scenario_id"][bus_batch]
-        local_bus_idx = torch.cat(
-            [
-                torch.arange(c, device=bus_batch.device)
-                for c in torch.bincount(bus_batch)
-            ],
-        )  # this works because the order of the buses is preserved by the groupby in the dataset wrapper and datakit data has buses in increasing order.
+        local_bus_idx = local_index_per_graph(bus_batch)
+        # this works because the order of the buses is preserved by the groupby in the dataset wrapper and datakit data has buses in increasing order.
 
         bus_x = batch.x_dict["bus"]
         bus_y = batch.y_dict["bus"]
@@ -578,17 +580,12 @@ class OptimalPowerFlowTask(ReconstructionTask):
         )
         gen_batch = batch.batch_dict["gen"]
         gen_scenario_ids = batch["scenario_id"][gen_batch]
-        local_gen_idx = torch.cat(
-            [
-                torch.arange(c, device=gen_batch.device)
-                for c in torch.bincount(gen_batch)
-            ],
-        )
+        local_gen_idx = local_index_per_graph(gen_batch)
         gen_x = batch.x_dict["gen"]
         gen_target = batch.y_dict["gen"].reshape(-1)
         gen_pred = output["gen"].reshape(-1)
 
-        return {
+        prediction_tables = {
             "bus": {
                 "scenario": scenario_ids.cpu().numpy(),
                 "bus": local_bus_idx.cpu().numpy(),
@@ -626,3 +623,23 @@ class OptimalPowerFlowTask(ReconstructionTask):
                 "cp2_eur_per_mw2": gen_x[:, C2_H].cpu().numpy(),
             },
         }
+        if embeddings is None:
+            return prediction_tables
+        if "bus" in embeddings:
+            prediction_tables["bus_embeddings"] = embedding_table_from_tensor(
+                embeddings["bus"],
+                id_columns={
+                    "scenario": scenario_ids.cpu().numpy(),
+                    "bus": local_bus_idx.cpu().numpy(),
+                },
+            )
+        if "gen" in embeddings:
+            prediction_tables["gen_embeddings"] = embedding_table_from_tensor(
+                embeddings["gen"],
+                id_columns={
+                    "scenario": gen_scenario_ids.cpu().numpy(),
+                    "idx": local_gen_idx.cpu().numpy(),
+                    "bus": local_bus_idx[gen_to_bus_index].cpu().numpy(),
+                },
+            )
+        return prediction_tables

--- a/gridfm_graphkit/tasks/opf_task.py
+++ b/gridfm_graphkit/tasks/opf_task.py
@@ -48,6 +48,7 @@ from gridfm_graphkit.models.utils import (
 import matplotlib.pyplot as plt
 import seaborn as sns
 from lightning.pytorch.loggers import MLFlowLogger
+from lightning.pytorch.utilities import rank_zero_warn
 import numpy as np
 import os
 import pandas as pd
@@ -643,4 +644,12 @@ class OptimalPowerFlowTask(ReconstructionTask):
                     "bus": local_bus_idx[gen_to_bus_index].cpu().numpy(),
                 },
             )
+        elif not getattr(self, "_warned_no_gen_embeddings", False):
+            # e.g. GRIT returns only bus embeddings. Warn once so the absence of
+            # a gen_embeddings parquet file is not mistaken for a bug.
+            rank_zero_warn(
+                f"get_embeddings is set but {type(self.model).__name__} does not "
+                "expose generator embeddings; only bus embeddings will be exported.",
+            )
+            self._warned_no_gen_embeddings = True
         return prediction_tables

--- a/gridfm_graphkit/tasks/pf_task.py
+++ b/gridfm_graphkit/tasks/pf_task.py
@@ -422,13 +422,12 @@ class PowerFlowTask(ReconstructionTask):
         self.test_outputs.clear()
 
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
-        embeddings = None
+        # Predict only needs the forward pass; shared_step would also compute a
+        # loss that is discarded here (and would require targets to be present).
         if getattr(self.args, "get_embeddings", False):
             output, embeddings = self.model(batch, return_embeddings=True)
         else:
-            output, _ = self.shared_step(
-                batch,
-            )  # get the predicted output from the model
+            output, embeddings = self.model(batch), None
 
         self.data_normalizers[dataloader_idx].inverse_transform(
             batch,

--- a/gridfm_graphkit/tasks/pf_task.py
+++ b/gridfm_graphkit/tasks/pf_task.py
@@ -21,6 +21,8 @@ from gridfm_graphkit.datasets.globals import (
 from gridfm_graphkit.tasks.reconstruction_tasks import ReconstructionTask
 from gridfm_graphkit.io.registries import TASK_REGISTRY
 from gridfm_graphkit.tasks.utils import (
+    embedding_table_from_tensor,
+    local_index_per_graph,
     plot_correlation_by_node_type,
     plot_residuals_histograms,
     residual_stats_by_type,
@@ -420,7 +422,13 @@ class PowerFlowTask(ReconstructionTask):
         self.test_outputs.clear()
 
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
-        output, _ = self.shared_step(batch)  # get the predicted output from the model
+        embeddings = None
+        if getattr(self.args, "get_embeddings", False):
+            output, embeddings = self.model(batch, return_embeddings=True)
+        else:
+            output, _ = self.shared_step(
+                batch,
+            )  # get the predicted output from the model
 
         self.data_normalizers[dataloader_idx].inverse_transform(
             batch,
@@ -478,12 +486,8 @@ class PowerFlowTask(ReconstructionTask):
 
         bus_batch = batch.batch_dict["bus"]
         scenario_ids = batch["scenario_id"][bus_batch]
-        local_bus_idx = torch.cat(
-            [
-                torch.arange(c, device=bus_batch.device)
-                for c in torch.bincount(bus_batch)
-            ],
-        )  # this is based on the assumptions that the buses within a graph are ordered and indexed as 0 ... n_nodes-1.
+        local_bus_idx = local_index_per_graph(bus_batch)
+        # this is based on the assumptions that the buses within a graph are ordered and indexed as 0 ... n_nodes-1.
         # todo: we should remove this assert and store the bus idx in the tensors
         # right now we need the increasing order and we have an assert in the dataset to check it.
         bus_x = batch.x_dict["bus"]
@@ -492,7 +496,7 @@ class PowerFlowTask(ReconstructionTask):
         mask_PV = batch.mask_dict["PV"]
         mask_REF = batch.mask_dict["REF"]
 
-        return {
+        prediction_table = {
             "scenario": scenario_ids.cpu().numpy(),
             "bus": local_bus_idx.cpu().numpy(),
             "Pd": bus_x[:, PD_H].cpu().numpy(),
@@ -515,4 +519,16 @@ class PowerFlowTask(ReconstructionTask):
             "active res. (MW)": residual_P.detach().cpu().numpy(),
             "reactive res. (MVar)": residual_Q.detach().cpu().numpy(),
             "PBE": residual_mva.detach().cpu().numpy(),
+        }
+        if embeddings is None or "bus" not in embeddings:
+            return prediction_table
+        return {
+            "bus": prediction_table,
+            "bus_embeddings": embedding_table_from_tensor(
+                embeddings["bus"],
+                id_columns={
+                    "scenario": scenario_ids.cpu().numpy(),
+                    "bus": local_bus_idx.cpu().numpy(),
+                },
+            ),
         }

--- a/gridfm_graphkit/tasks/utils.py
+++ b/gridfm_graphkit/tasks/utils.py
@@ -6,6 +6,32 @@ import numpy as np
 import os
 
 
+def local_index_per_graph(batch_index: torch.Tensor) -> torch.Tensor:
+    """Return 0..N-1 local indices for each graph in a batched entity axis."""
+
+    return torch.cat(
+        [
+            torch.arange(int(count), device=batch_index.device)
+            for count in torch.bincount(batch_index)
+        ],
+    )
+
+
+def embedding_table_from_tensor(
+    embedding: torch.Tensor,
+    *,
+    id_columns: dict[str, np.ndarray],
+    prefix: str = "emb",
+) -> dict[str, np.ndarray]:
+    """Convert one embedding tensor into a parquet-ready table mapping."""
+
+    values = embedding.detach().cpu().numpy()
+    table = {key: value for key, value in id_columns.items()}
+    for index in range(values.shape[1]):
+        table[f"{prefix}_{index:03d}"] = values[:, index]
+    return table
+
+
 def residual_stats_by_type(residual, mask, bus_batch):
     """Return per-graph mean and max absolute residuals for a masked bus subset."""
     residual_masked = residual[mask]

--- a/tests/test_predict_embeddings.py
+++ b/tests/test_predict_embeddings.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 from gridfm_graphkit.__main__ import main
 from gridfm_graphkit.cli import _prediction_output_filename, main_cli
+from gridfm_graphkit.models.gnn_heterogeneous_gns import GNS_heterogeneous
 from gridfm_graphkit.models.grit_transformer import GritHeteroAdapter
 from gridfm_graphkit.tasks.utils import (
     embedding_table_from_tensor,
@@ -572,3 +573,89 @@ def test_main_cli_predict_saves_opf_embedding_tables(tmp_path) -> None:
         "emb_000",
     ]
     assert all(not index for _, _, index in saved.values())
+
+
+class _Const(torch.nn.Module):
+    """Returns a constant tensor of width ``out_dim``, one row per input row."""
+
+    def __init__(self, out_dim: int, value: float = 0.0):
+        super().__init__()
+        self.out_dim = out_dim
+        self.value = value
+
+    def forward(self, x):
+        return torch.full((x.shape[0], self.out_dim), self.value)
+
+
+def test_gns_bus_embedding_excludes_final_physics_update() -> None:
+    """The exported bus embedding must be the tensor that fed ``mlp_bus``.
+
+    The physics-residual update is skipped on the last layer, so ``h_bus`` at
+    the return is exactly that tensor. ``physics_mlp`` returns a huge constant,
+    so if the final update were reapplied the embedding would blow up.
+    """
+    n_bus, n_gen, hidden = 3, 2, 4
+    model = object.__new__(GNS_heterogeneous)
+    torch.nn.Module.__init__(model)
+
+    # Two layers: layer 0 applies the physics update, layer 1 must not.
+    model.task = "PowerFlow"
+    model.num_layers = 2
+    model.activation = torch.nn.Identity()
+    model.layer_residuals = {}
+    model.input_proj_bus = _Const(hidden, 2.0)
+    model.input_proj_gen = _Const(hidden, 3.0)
+    model.input_proj_edge = torch.nn.Identity()
+    model.layers = [lambda h, ei, ea: dict(h)] * 2
+    model.norms_bus = [torch.nn.Identity()] * 2
+    model.norms_gen = [torch.nn.Identity()] * 2
+    model.mlp_bus = _Const(2, 1.0)
+    model.mlp_gen = _Const(1, 1.0)
+    model.physics_mlp = _Const(hidden, 1e6)
+    model.branch_flow_layer = lambda bus, ei, ea: (
+        torch.zeros(ei.shape[1]),
+        torch.zeros(ei.shape[1]),
+    )
+    model.node_injection_layer = lambda p, q, ei, nb: (
+        torch.zeros(nb),
+        torch.zeros(nb),
+    )
+    model.physics_decoder = lambda p, q, bus_temp, bus_x, agg, md: torch.zeros(
+        (n_bus, 4),
+    )
+    model.node_residuals_layer = lambda p, q, out, bus_x: (
+        torch.zeros(n_bus),
+        torch.zeros(n_bus),
+    )
+
+    batch = SimpleNamespace(
+        x_dict={"bus": torch.zeros((n_bus, 16)), "gen": torch.zeros((n_gen, 8))},
+        edge_index_dict={
+            ("bus", "connects", "bus"): torch.tensor([[0, 1], [1, 2]]),
+            ("gen", "connected_to", "bus"): torch.tensor([[0, 1], [0, 1]]),
+        },
+        edge_attr_dict={
+            ("bus", "connects", "bus"): torch.zeros((2, 2)),
+            ("gen", "connected_to", "bus"): None,
+        },
+        mask_dict={
+            "bus": torch.ones((n_bus, 16), dtype=torch.bool),
+            "gen": torch.ones((n_gen, 8), dtype=torch.bool),
+        },
+    )
+
+    _, embeddings = model(batch, return_embeddings=True)
+
+    # layer 0: h_bus = 2.0 (proj) + 2.0 (identity conv) = 4.0, then += 1e6.
+    # layer 1: h_bus = 1e6+4 doubled by the skip connection, and NO further update.
+    expected = torch.full((n_bus, hidden), (1e6 + 4.0) * 2)
+    torch.testing.assert_close(embeddings["bus"], expected)
+
+    # The final layer's physics update must not be included.
+    assert not torch.allclose(
+        embeddings["bus"],
+        expected + 1e6,
+    ), "bus embedding includes the final-layer physics update"
+
+    # layer_residuals must still be recorded for every layer (the loss reads all).
+    assert sorted(model.layer_residuals) == [0, 1]

--- a/tests/test_predict_embeddings.py
+++ b/tests/test_predict_embeddings.py
@@ -98,7 +98,7 @@ def test_predict_parser_accepts_get_embeddings_flag() -> None:
         "examples/config/HGNS_PF_118Bus.yaml",
         "--model_path",
         "tests/models/dummy_model.pt",
-        "--get-embeddings",
+        "--get_embeddings",
     ]
 
     with (

--- a/tests/test_predict_embeddings.py
+++ b/tests/test_predict_embeddings.py
@@ -1,0 +1,574 @@
+import numpy as np
+import torch
+import yaml
+from unittest import mock
+from types import SimpleNamespace
+
+from gridfm_graphkit.__main__ import main
+from gridfm_graphkit.cli import _prediction_output_filename, main_cli
+from gridfm_graphkit.models.grit_transformer import GritHeteroAdapter
+from gridfm_graphkit.tasks.utils import (
+    embedding_table_from_tensor,
+    local_index_per_graph,
+)
+
+
+def test_prediction_output_filename_handles_embeddings() -> None:
+    assert _prediction_output_filename("case14", "bus") == "case14_predictions.parquet"
+    assert (
+        _prediction_output_filename("case14", "gen") == "case14_gen_predictions.parquet"
+    )
+    assert (
+        _prediction_output_filename("case14", "bus_embeddings")
+        == "case14_bus_embeddings.parquet"
+    )
+    assert (
+        _prediction_output_filename("case14", "gen_embeddings")
+        == "case14_gen_embeddings.parquet"
+    )
+
+
+def test_local_index_per_graph_builds_local_entity_ids() -> None:
+    batch_index = torch.tensor([0, 0, 0, 1, 1, 2], dtype=torch.long)
+    torch.testing.assert_close(
+        local_index_per_graph(batch_index),
+        torch.tensor([0, 1, 2, 0, 1, 0], dtype=torch.long),
+    )
+
+
+def test_embedding_table_from_tensor_formats_columns() -> None:
+    embedding = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
+    table = embedding_table_from_tensor(
+        embedding,
+        id_columns={"scenario": np.array([10, 11]), "bus": np.array([0, 1])},
+    )
+    assert list(table) == ["scenario", "bus", "emb_000", "emb_001"]
+    np.testing.assert_allclose(table["emb_000"], np.array([1.0, 3.0]))
+    np.testing.assert_allclose(table["emb_001"], np.array([2.0, 4.0]))
+
+
+def test_grit_adapter_returns_bus_embeddings_when_requested() -> None:
+    adapter = object.__new__(GritHeteroAdapter)
+    torch.nn.Module.__init__(adapter)
+    adapter.grit = SimpleNamespace(
+        mask_value=torch.tensor([-1.0], dtype=torch.float32),
+        encoder=lambda homo: homo,
+        layers=lambda homo: homo,
+    )
+    adapter.bus_head = torch.nn.Identity()
+    adapter.gen_head = torch.nn.Identity()
+
+    batch = {
+        "bus": SimpleNamespace(
+            x=torch.arange(30, dtype=torch.float32).reshape(2, 15),
+            y=torch.zeros((2, 2), dtype=torch.float32),
+            batch=torch.tensor([0, 0], dtype=torch.long),
+        ),
+        "gen": SimpleNamespace(
+            x=torch.arange(12, dtype=torch.float32).reshape(2, 6),
+        ),
+        ("bus", "connects", "bus"): SimpleNamespace(
+            edge_index=torch.tensor([[0, 1], [1, 0]], dtype=torch.long),
+            edge_attr=torch.zeros((2, 1), dtype=torch.float32),
+        ),
+    }
+    batch = type("FakeBatch", (dict,), {"edge_types": ()})(batch)
+
+    aggregated_pg = torch.tensor([100.0, 200.0], dtype=torch.float32)
+    with mock.patch(
+        "gridfm_graphkit.models.grit_transformer.aggregate_pg",
+        return_value=aggregated_pg,
+    ):
+        predictions, embeddings = adapter(batch, return_embeddings=True)
+
+    expected_bus_features = torch.cat(
+        [batch["bus"].x, aggregated_pg.unsqueeze(-1)],
+        dim=-1,
+    )
+    torch.testing.assert_close(predictions["bus"], expected_bus_features)
+    torch.testing.assert_close(embeddings["bus"], expected_bus_features)
+    torch.testing.assert_close(predictions["gen"], batch["gen"].x)
+
+
+def test_predict_parser_accepts_get_embeddings_flag() -> None:
+    test_argv = [
+        "gridfm_graphkit",
+        "predict",
+        "--config",
+        "examples/config/HGNS_PF_118Bus.yaml",
+        "--model_path",
+        "tests/models/dummy_model.pt",
+        "--get-embeddings",
+    ]
+
+    with (
+        mock.patch("sys.argv", test_argv),
+        mock.patch(
+            "gridfm_graphkit.__main__.main_cli",
+        ) as mocked_main_cli,
+    ):
+        main()
+
+    parsed_args = mocked_main_cli.call_args.args[0]
+    assert parsed_args.command == "predict"
+    assert parsed_args.get_embeddings is True
+
+
+def test_main_cli_propagates_get_embeddings_to_task_args(tmp_path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "seed": 0,
+                "task": {"task_name": "PowerFlow"},
+                "data": {
+                    "networks": ["case14"],
+                    "workers": 0,
+                    "baseMVA": 100,
+                },
+                "training": {
+                    "accelerator": "cpu",
+                    "devices": 1,
+                    "strategy": "auto",
+                    "epochs": 1,
+                    "batch_size": 1,
+                },
+                "callbacks": {"tol": 0.0, "patience": 1},
+                "optimizer": {
+                    "learning_rate": 1e-3,
+                    "beta1": 0.9,
+                    "beta2": 0.999,
+                    "lr_decay": 0.5,
+                    "lr_patience": 1,
+                },
+            },
+        ),
+    )
+
+    args = SimpleNamespace(
+        tf32=False,
+        log_dir=str(tmp_path / "mlruns"),
+        exp_name="tests",
+        run_name="predict-embeddings",
+        config=str(config_path),
+        data_path=str(tmp_path / "data"),
+        model_path=str(tmp_path / "model.pt"),
+        command="predict",
+        output_path=str(tmp_path / "out"),
+        get_embeddings=True,
+        num_workers=0,
+        batch_size=None,
+        plugins=[],
+        dataset_wrapper=None,
+        dataset_wrapper_cache_dir=None,
+        mp_context=None,
+        normalizer_stats=None,
+        bfloat16=False,
+        compile=None,
+        profiler=None,
+        report_performance=False,
+        deterministic=False,
+        compute_dc_ac_metrics=False,
+        save_output=False,
+    )
+
+    logger = SimpleNamespace(
+        save_dir=str(tmp_path / "mlruns"),
+        experiment_id="0",
+        run_id="0",
+    )
+    captured = {}
+
+    class DummyModel:
+        def __init__(self):
+            self.model = self
+
+        def load_state_dict(self, _state_dict):
+            return None
+
+    class DummyDataModule:
+        def __init__(self, *args, **kwargs):
+            self.data_normalizers = [object()]
+
+    class DummyTrainer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def predict(self, model=None, datamodule=None):
+            return [
+                {
+                    "bus": {
+                        "scenario": np.array([0]),
+                        "vm_pu": np.array([1.0]),
+                    },
+                    "bus_embeddings": {
+                        "scenario": np.array([0]),
+                        "bus": np.array([0]),
+                        "emb_000": np.array([0.1]),
+                    },
+                },
+            ]
+
+    def fake_get_task(config_args, data_normalizers):
+        captured["get_embeddings"] = getattr(config_args, "get_embeddings", None)
+        return DummyModel()
+
+    with (
+        mock.patch("gridfm_graphkit.cli.MLFlowLogger", return_value=logger),
+        mock.patch(
+            "gridfm_graphkit.cli.L.seed_everything",
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.LitGridHeteroDataModule",
+            DummyDataModule,
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.get_task",
+            side_effect=fake_get_task,
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.L.Trainer",
+            DummyTrainer,
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.torch.load",
+            return_value={},
+        ),
+        mock.patch(
+            "pandas.DataFrame.to_parquet",
+        ),
+    ):
+        main_cli(args)
+
+    assert captured["get_embeddings"] is True
+
+
+def test_main_cli_predict_saves_pf_embedding_tables(tmp_path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "seed": 0,
+                "task": {"task_name": "PowerFlow"},
+                "data": {
+                    "networks": ["case14"],
+                    "workers": 0,
+                    "baseMVA": 100,
+                },
+                "training": {
+                    "accelerator": "cpu",
+                    "devices": 1,
+                    "strategy": "auto",
+                    "epochs": 1,
+                    "batch_size": 1,
+                },
+                "callbacks": {"tol": 0.0, "patience": 1},
+                "optimizer": {
+                    "learning_rate": 1e-3,
+                    "beta1": 0.9,
+                    "beta2": 0.999,
+                    "lr_decay": 0.5,
+                    "lr_patience": 1,
+                },
+            },
+        ),
+    )
+
+    args = SimpleNamespace(
+        tf32=False,
+        log_dir=str(tmp_path / "mlruns"),
+        exp_name="tests",
+        run_name="predict-pf-embeddings",
+        config=str(config_path),
+        data_path=str(tmp_path / "data"),
+        model_path=str(tmp_path / "model.pt"),
+        command="predict",
+        output_path=str(tmp_path / "out"),
+        get_embeddings=True,
+        num_workers=0,
+        batch_size=None,
+        plugins=[],
+        dataset_wrapper=None,
+        dataset_wrapper_cache_dir=None,
+        mp_context=None,
+        normalizer_stats=None,
+        bfloat16=False,
+        compile=None,
+        profiler=None,
+        report_performance=False,
+        deterministic=False,
+        compute_dc_ac_metrics=False,
+        save_output=False,
+    )
+
+    logger = SimpleNamespace(
+        save_dir=str(tmp_path / "mlruns"),
+        experiment_id="0",
+        run_id="0",
+    )
+    writes = []
+
+    class DummyModel:
+        def __init__(self):
+            self.model = self
+
+        def load_state_dict(self, _state_dict):
+            return None
+
+    class DummyDataModule:
+        def __init__(self, *args, **kwargs):
+            self.data_normalizers = [object()]
+
+    class DummyTrainer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def predict(self, model=None, datamodule=None):
+            return [
+                {
+                    "bus": {
+                        "scenario": np.array([0]),
+                        "bus": np.array([0]),
+                        "Vm_pred": np.array([1.0]),
+                    },
+                    "bus_embeddings": {
+                        "scenario": np.array([0]),
+                        "bus": np.array([0]),
+                        "emb_000": np.array([0.1]),
+                    },
+                },
+                {
+                    "bus": {
+                        "scenario": np.array([1]),
+                        "bus": np.array([1]),
+                        "Vm_pred": np.array([1.1]),
+                    },
+                    "bus_embeddings": {
+                        "scenario": np.array([1]),
+                        "bus": np.array([1]),
+                        "emb_000": np.array([0.2]),
+                    },
+                },
+            ]
+
+    def fake_to_parquet(df, path, index=False):
+        writes.append((str(path).split("/")[-1], list(df.columns), df.shape, index))
+
+    with (
+        mock.patch("gridfm_graphkit.cli.MLFlowLogger", return_value=logger),
+        mock.patch(
+            "gridfm_graphkit.cli.L.seed_everything",
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.LitGridHeteroDataModule",
+            DummyDataModule,
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.get_task",
+            return_value=DummyModel(),
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.L.Trainer",
+            DummyTrainer,
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.torch.load",
+            return_value={},
+        ),
+        mock.patch(
+            "pandas.DataFrame.to_parquet",
+            new=fake_to_parquet,
+        ),
+    ):
+        main_cli(args)
+
+    saved = {name: (columns, shape, index) for name, columns, shape, index in writes}
+    assert set(saved) == {
+        "case14_predictions.parquet",
+        "case14_bus_embeddings.parquet",
+    }
+    assert saved["case14_predictions.parquet"][1] == (2, 3)
+    assert saved["case14_bus_embeddings.parquet"][0] == ["scenario", "bus", "emb_000"]
+    assert all(not index for _, _, index in saved.values())
+
+
+def test_main_cli_predict_saves_opf_embedding_tables(tmp_path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "seed": 0,
+                "task": {"task_name": "OptimalPowerFlow"},
+                "data": {
+                    "networks": ["case14"],
+                    "workers": 0,
+                    "baseMVA": 100,
+                },
+                "training": {
+                    "accelerator": "cpu",
+                    "devices": 1,
+                    "strategy": "auto",
+                    "epochs": 1,
+                    "batch_size": 1,
+                },
+                "callbacks": {"tol": 0.0, "patience": 1},
+                "optimizer": {
+                    "learning_rate": 1e-3,
+                    "beta1": 0.9,
+                    "beta2": 0.999,
+                    "lr_decay": 0.5,
+                    "lr_patience": 1,
+                },
+            },
+        ),
+    )
+
+    args = SimpleNamespace(
+        tf32=False,
+        log_dir=str(tmp_path / "mlruns"),
+        exp_name="tests",
+        run_name="predict-opf-embeddings",
+        config=str(config_path),
+        data_path=str(tmp_path / "data"),
+        model_path=str(tmp_path / "model.pt"),
+        command="predict",
+        output_path=str(tmp_path / "out"),
+        get_embeddings=True,
+        num_workers=0,
+        batch_size=None,
+        plugins=[],
+        dataset_wrapper=None,
+        dataset_wrapper_cache_dir=None,
+        mp_context=None,
+        normalizer_stats=None,
+        bfloat16=False,
+        compile=None,
+        profiler=None,
+        report_performance=False,
+        deterministic=False,
+        compute_dc_ac_metrics=False,
+        save_output=False,
+    )
+
+    logger = SimpleNamespace(
+        save_dir=str(tmp_path / "mlruns"),
+        experiment_id="0",
+        run_id="0",
+    )
+    writes = []
+
+    class DummyModel:
+        def __init__(self):
+            self.model = self
+
+        def load_state_dict(self, _state_dict):
+            return None
+
+    class DummyDataModule:
+        def __init__(self, *args, **kwargs):
+            self.data_normalizers = [object()]
+
+    class DummyTrainer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def predict(self, model=None, datamodule=None):
+            return [
+                {
+                    "bus": {
+                        "scenario": np.array([0]),
+                        "bus": np.array([0]),
+                        "Vm_pred": np.array([1.0]),
+                    },
+                    "gen": {
+                        "scenario": np.array([0]),
+                        "idx": np.array([0]),
+                        "bus": np.array([0]),
+                        "p_mw_pred": np.array([10.0]),
+                    },
+                    "bus_embeddings": {
+                        "scenario": np.array([0]),
+                        "bus": np.array([0]),
+                        "emb_000": np.array([0.1]),
+                    },
+                    "gen_embeddings": {
+                        "scenario": np.array([0]),
+                        "idx": np.array([0]),
+                        "bus": np.array([0]),
+                        "emb_000": np.array([0.2]),
+                    },
+                },
+                {
+                    "bus": {
+                        "scenario": np.array([1]),
+                        "bus": np.array([1]),
+                        "Vm_pred": np.array([1.1]),
+                    },
+                    "gen": {
+                        "scenario": np.array([1]),
+                        "idx": np.array([1]),
+                        "bus": np.array([1]),
+                        "p_mw_pred": np.array([11.0]),
+                    },
+                    "bus_embeddings": {
+                        "scenario": np.array([1]),
+                        "bus": np.array([1]),
+                        "emb_000": np.array([0.3]),
+                    },
+                    "gen_embeddings": {
+                        "scenario": np.array([1]),
+                        "idx": np.array([1]),
+                        "bus": np.array([1]),
+                        "emb_000": np.array([0.4]),
+                    },
+                },
+            ]
+
+    def fake_to_parquet(df, path, index=False):
+        writes.append((str(path).split("/")[-1], list(df.columns), df.shape, index))
+
+    with (
+        mock.patch("gridfm_graphkit.cli.MLFlowLogger", return_value=logger),
+        mock.patch(
+            "gridfm_graphkit.cli.L.seed_everything",
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.LitGridHeteroDataModule",
+            DummyDataModule,
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.get_task",
+            return_value=DummyModel(),
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.L.Trainer",
+            DummyTrainer,
+        ),
+        mock.patch(
+            "gridfm_graphkit.cli.torch.load",
+            return_value={},
+        ),
+        mock.patch(
+            "pandas.DataFrame.to_parquet",
+            new=fake_to_parquet,
+        ),
+    ):
+        main_cli(args)
+
+    saved = {name: (columns, shape, index) for name, columns, shape, index in writes}
+    assert set(saved) == {
+        "case14_predictions.parquet",
+        "case14_gen_predictions.parquet",
+        "case14_bus_embeddings.parquet",
+        "case14_gen_embeddings.parquet",
+    }
+    assert saved["case14_predictions.parquet"][1] == (2, 3)
+    assert saved["case14_gen_predictions.parquet"][1] == (2, 4)
+    assert saved["case14_bus_embeddings.parquet"][0] == ["scenario", "bus", "emb_000"]
+    assert saved["case14_gen_embeddings.parquet"][0] == [
+        "scenario",
+        "idx",
+        "bus",
+        "emb_000",
+    ]
+    assert all(not index for _, _, index in saved.values())


### PR DESCRIPTION
**Description**

This PR adds optional embedding export to `gridfm_graphkit predict` so model latent representations can be saved alongside the standard prediction outputs.

The main motivation is to support the development of TrustLayer, in particular downstream workflows that need access to learned embeddings for similarity-aware analysis and kernel-weighted conformal prediction.

**What changed**
- Added a new `--get-embeddings` flag to the `predict` CLI.
- Extended the prediction export path to save embedding parquet files when requested.
- Added embedding support for both `GNS_heterogeneous` and `GRIT`.
- Exported:
  - PF: bus embeddings
  - OPF: bus embeddings and generator embeddings when available from the active model
- Kept the default behavior unchanged when embeddings are not requested.
- Added shared utilities for formatting embedding tables and building per-graph local indices.
- Added focused regression tests for:
  - CLI flag parsing and propagation
  - PF embedding save path
  - OPF embedding save path
  - GRIT embedding return path
  - embedding table formatting helpers
- Updated the predict command documentation with the new flag.

**Output format**
When enabled, prediction runs now save the usual prediction parquet files plus embedding parquet files keyed by entity identifiers such as `scenario`, `bus`, and `idx`, with embedding columns named `emb_000`, `emb_001`, and so on.

**Why this matters for TrustLayer**
These exported embeddings will be used as a representation space for TrustLayer development, including kernel-weighted conformal prediction and related similarity-based trust and calibration methods.

**Validation**
- Focused embedding tests pass.
- YAML config loading tests pass.
