### PR TITLE
Add memory-bounded streaming preprocessing for Hive-partitioned parquet

### DIFF
--- a/docs/quick_start/yaml_config.md
+++ b/docs/quick_start/yaml_config.md
@@ -140,6 +140,8 @@ Controls whether `process()` reads raw parquet data partition-by-partition (stre
 - `on`: require Hive partitions; raises `RuntimeError` with a clear message if the raw directory is flat.
 - `off`: force the legacy flat-file path even if partitions exist.
 
+**Data layout requirements for streaming:** all three tables must expose the same set of `scenario_partition` values, and every scenario's rows must be fully contained within a single partition. Violations are caught early with a clear error.
+
 The CLI flag `--stream-partitions` overrides this YAML value.
 
 ## `model` section

--- a/docs/quick_start/yaml_config.md
+++ b/docs/quick_start/yaml_config.md
@@ -132,6 +132,16 @@ Optional path to precomputed split files. When provided:
 - `data.scenarios` is ignored for split construction,
 - do **not** combine with `split_by_load_scenario_idx: true`.
 
+### `data.stream_partitions`
+
+Controls whether `process()` reads raw parquet data partition-by-partition (streaming) or all at once (legacy). Activated automatically when raw parquet is laid out as Hive partitions (`scenario_partition=<n>/` subdirectories).
+
+- `auto` (default): stream if Hive partitions are detected for all three tables (bus, gen, branch), otherwise fall back to the legacy flat-file path.
+- `on`: require Hive partitions; raises `RuntimeError` with a clear message if the raw directory is flat.
+- `off`: force the legacy flat-file path even if partitions exist.
+
+The CLI flag `--stream-partitions` overrides this YAML value.
+
 ## `model` section
 
 Current configs use the heterogeneous GNS model:

--- a/examples/config/GRIT_PF_datakit_case14.yaml
+++ b/examples/config/GRIT_PF_datakit_case14.yaml
@@ -39,6 +39,7 @@ data:
     cache: true   # cache the computed positional encoding at first pass (if false computes every access)
     kernel:
       times: 21
+  stream_partitions: auto
 model:
   attention_head: 8
   dropout: 0.1

--- a/examples/config/HGNS_OPF_Ola_case118.yaml
+++ b/examples/config/HGNS_OPF_Ola_case118.yaml
@@ -12,6 +12,7 @@ data:
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: false
   split_from_existing_files: "/dccstor/gridfm/march_opf_exp/opfdata_olay_splits/"
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_Ola_case14.yaml
+++ b/examples/config/HGNS_OPF_Ola_case14.yaml
@@ -12,6 +12,7 @@ data:
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: false
   split_from_existing_files: "/dccstor/gridfm/march_opf_exp/opfdata_olay_splits/"
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_Ola_case2000.yaml
+++ b/examples/config/HGNS_OPF_Ola_case2000.yaml
@@ -12,6 +12,7 @@ data:
   workers: 16 # 4 gpus
   split_by_load_scenario_idx: false
   split_from_existing_files: "/dccstor/gridfm/march_opf_exp/opfdata_olay_splits/"
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_Ola_case30.yaml
+++ b/examples/config/HGNS_OPF_Ola_case30.yaml
@@ -12,6 +12,7 @@ data:
   workers: 32
   split_by_load_scenario_idx: false
   split_from_existing_files: "/dccstor/gridfm/march_opf_exp/opfdata_olay_splits/"
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_Ola_case500.yaml
+++ b/examples/config/HGNS_OPF_Ola_case500.yaml
@@ -12,6 +12,7 @@ data:
   workers: 16 # 2 gpus
   split_by_load_scenario_idx: false
   split_from_existing_files: "/dccstor/gridfm/march_opf_exp/opfdata_olay_splits/"
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_Ola_case57.yaml
+++ b/examples/config/HGNS_OPF_Ola_case57.yaml
@@ -12,6 +12,7 @@ data:
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: false
   split_from_existing_files: "/dccstor/gridfm/march_opf_exp/opfdata_olay_splits/"
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_datakit_case118.yaml
+++ b/examples/config/HGNS_OPF_datakit_case118.yaml
@@ -13,6 +13,7 @@ data:
   val_ratio: 0.1
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_datakit_case14.yaml
+++ b/examples/config/HGNS_OPF_datakit_case14.yaml
@@ -13,6 +13,7 @@ data:
   val_ratio: 0.1
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_datakit_case2000.yaml
+++ b/examples/config/HGNS_OPF_datakit_case2000.yaml
@@ -13,6 +13,7 @@ data:
   val_ratio: 0.1
   workers: 16 # 4 gpus
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_datakit_case30.yaml
+++ b/examples/config/HGNS_OPF_datakit_case30.yaml
@@ -13,6 +13,7 @@ data:
   val_ratio: 0.1
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_datakit_case500.yaml
+++ b/examples/config/HGNS_OPF_datakit_case500.yaml
@@ -13,6 +13,7 @@ data:
   val_ratio: 0.1
   workers: 16 # 2 gpus
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_OPF_datakit_case57.yaml
+++ b/examples/config/HGNS_OPF_datakit_case57.yaml
@@ -13,6 +13,7 @@ data:
   val_ratio: 0.1
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_PF_datakit_case118.yaml
+++ b/examples/config/HGNS_PF_datakit_case118.yaml
@@ -19,6 +19,7 @@ data:
   val_ratio: 0.1
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_PF_datakit_case14.yaml
+++ b/examples/config/HGNS_PF_datakit_case14.yaml
@@ -19,6 +19,7 @@ data:
   val_ratio: 0.1
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_PF_datakit_case2000.yaml
+++ b/examples/config/HGNS_PF_datakit_case2000.yaml
@@ -19,6 +19,7 @@ data:
   val_ratio: 0.1
   workers: 16 # 4 gpus
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_PF_datakit_case30.yaml
+++ b/examples/config/HGNS_PF_datakit_case30.yaml
@@ -19,6 +19,7 @@ data:
   val_ratio: 0.1
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_PF_datakit_case500.yaml
+++ b/examples/config/HGNS_PF_datakit_case500.yaml
@@ -19,6 +19,7 @@ data:
   val_ratio: 0.1
   workers: 16 # 2 gpus
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_PF_datakit_case57.yaml
+++ b/examples/config/HGNS_PF_datakit_case57.yaml
@@ -19,6 +19,7 @@ data:
   val_ratio: 0.1
   workers: 32 # 1 gpu
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/examples/config/HGNS_PF_datakit_caseTexas.yaml
+++ b/examples/config/HGNS_PF_datakit_caseTexas.yaml
@@ -19,6 +19,7 @@ data:
   val_ratio: 0.1
   workers: 16 # 4 gpus
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/gridfm_graphkit/__main__.py
+++ b/gridfm_graphkit/__main__.py
@@ -177,6 +177,13 @@ def main():
             "sibling '<config>.v<N>.yaml' next to the original config."
         ),
     )
+    _stream_partitions_kwargs = dict(
+        dest="stream_partitions",
+        type=str,
+        default=None,
+        choices=["auto", "on", "off"],
+        help="Override data.stream_partitions from YAML. auto=detect, on=force+error, off=legacy.",
+    )
 
     # ---- TRAIN SUBCOMMAND ----
     train_parser = subparsers.add_parser("train", help="Run training")
@@ -236,6 +243,7 @@ def main():
         "--converted_config_path",
         **_converted_config_path_kwargs,
     )
+    train_parser.add_argument("--stream-partitions", **_stream_partitions_kwargs)
 
     # ---- FINETUNE SUBCOMMAND ----
     finetune_parser = subparsers.add_parser("finetune", help="Run fine-tuning")
@@ -295,6 +303,7 @@ def main():
         "--converted_config_path",
         **_converted_config_path_kwargs,
     )
+    finetune_parser.add_argument("--stream-partitions", **_stream_partitions_kwargs)
 
     # ---- EVALUATE SUBCOMMAND ----
     evaluate_parser = subparsers.add_parser(
@@ -367,6 +376,7 @@ def main():
         "--converted_config_path",
         **_converted_config_path_kwargs,
     )
+    evaluate_parser.add_argument("--stream-partitions", **_stream_partitions_kwargs)
 
     # ---- PREDICT SUBCOMMAND ----
     predict_parser = subparsers.add_parser("predict", help="Run prediction")
@@ -428,6 +438,7 @@ def main():
         "--converted_config_path",
         **_converted_config_path_kwargs,
     )
+    predict_parser.add_argument("--stream-partitions", **_stream_partitions_kwargs)
 
     # ---- BENCHMARK SUBCOMMAND ----
     benchmark_parser = subparsers.add_parser(

--- a/gridfm_graphkit/cli.py
+++ b/gridfm_graphkit/cli.py
@@ -232,6 +232,11 @@ def main_cli(args):
     if batch_size_override is not None:
         config_args.training.batch_size = batch_size_override
 
+    # CLI --stream-partitions overrides data.stream_partitions from YAML
+    stream_partitions_override = getattr(args, "stream_partitions", None)
+    if stream_partitions_override is not None:
+        config_args.data.stream_partitions = stream_partitions_override
+
     _load_plugins(getattr(args, "plugins", []))
     _validate_dataset_wrapper(dataset_wrapper)
 

--- a/gridfm_graphkit/datasets/hetero_powergrid_datamodule.py
+++ b/gridfm_graphkit/datasets/hetero_powergrid_datamodule.py
@@ -109,6 +109,7 @@ class LitGridHeteroDataModule(L.LightningDataModule):
         self.dataset_wrapper_cache_dir = dataset_wrapper_cache_dir
         self.multiprocessing_context = multiprocessing_context
         self.batch_size = int(args.training.batch_size)
+        self.stream_partitions = getattr(args.data, "stream_partitions", "auto")
         self.split_by_load_scenario_idx = getattr(
             args.data,
             "split_by_load_scenario_idx",
@@ -174,6 +175,7 @@ class LitGridHeteroDataModule(L.LightningDataModule):
                     root=data_path_network,
                     data_normalizer=data_normalizer,
                     transform=get_task_transforms(args=self.args),
+                    stream_partitions=self.stream_partitions,
                 )
 
             # All ranks wait here until rank 0 processing is done
@@ -185,6 +187,7 @@ class LitGridHeteroDataModule(L.LightningDataModule):
                     root=data_path_network,
                     data_normalizer=data_normalizer,
                     transform=get_task_transforms(args=self.args),
+                    stream_partitions=self.stream_partitions,
                 )
 
             if ("posenc_RRWP" in self.args.data) and self.args.data.posenc_RRWP.enable:

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -34,7 +34,15 @@ class HeteroGridDatasetDisk(Dataset):
         transform: Optional[Callable] = None,
         pre_transform: Optional[Callable] = None,
         pre_filter: Optional[Callable] = None,
+        stream_partitions: str = "auto",
     ):
+        _VALID = {"auto", "on", "off"}
+        if stream_partitions not in _VALID:
+            raise ValueError(
+                f"stream_partitions={stream_partitions!r} is not valid; "
+                f"choose one of {sorted(_VALID)}"
+            )
+        self.stream_partitions = stream_partitions
         self.data_normalizer = data_normalizer
         self.length = None
 
@@ -62,6 +70,21 @@ class HeteroGridDatasetDisk(Dataset):
         pass
 
     def process(self):
+        partitions = self._detect_partitions()
+
+        if self.stream_partitions == "on":
+            if partitions is None:
+                raise RuntimeError(
+                    f"stream_partitions='on' requires Hive-partitioned parquet, "
+                    f"but detected flat files in {self.raw_dir!r}. Use 'auto' or 'off'."
+                )
+            return self._process_streaming(partitions)
+
+        if self.stream_partitions == "auto" and partitions is not None:
+            print(f"Detected {len(partitions)} Hive partitions — using streaming mode.")
+            return self._process_streaming(partitions)
+
+        # stream_partitions == "off", or "auto" with no partitions detected → legacy path
         print("LOADING DATA")
         bus_data = pd.read_parquet(osp.join(self.raw_dir, "bus_data.parquet"))
         gen_data = pd.read_parquet(osp.join(self.raw_dir, "gen_data.parquet"))
@@ -94,52 +117,6 @@ class HeteroGridDatasetDisk(Dataset):
             print("Processed files already exist. Skipping processing.")
             return
 
-        bus_features = [
-            "Pd",
-            "Qd",
-            "Qg",
-            "Vm",
-            "Va",
-            "PQ",
-            "PV",
-            "REF",
-            "min_vm_pu",
-            "max_vm_pu",
-            "min_q_mvar",
-            "max_q_mvar",
-            "GS",
-            "BS",
-            "vn_kv",
-        ]
-
-        gen_features = [
-            "p_mw",
-            "min_p_mw",
-            "max_p_mw",
-            "cp0_eur",
-            "cp1_eur_per_mw",
-            "cp2_eur_per_mw2",
-            "in_service",
-        ]
-
-        common_branch_features = ["tap", "ang_min", "ang_max", "rate_a", "br_status"]
-        forward_branch_features = [
-            "pf",
-            "qf",
-            "Yff_r",
-            "Yff_i",
-            "Yft_r",
-            "Yft_i",
-        ] + common_branch_features
-        reverse_branch_features = [
-            "pt",
-            "qt",
-            "Ytt_r",
-            "Ytt_i",
-            "Ytf_r",
-            "Ytf_i",
-        ] + common_branch_features
-
         # Group by scenario
         bus_groups = bus_data.groupby(
             "scenario",
@@ -159,87 +136,199 @@ class HeteroGridDatasetDisk(Dataset):
                 scenario not in gen_groups.groups
                 or scenario not in branch_groups.groups
             ):
-                raise ValueError
+                raise ValueError(
+                    f"Scenario {scenario} is missing generator or branch data."
+                )
 
-            data = HeteroData()
-
-            # Bus nodes
-            bus_df = bus_groups.get_group(scenario)
-            # assert that the buses are in increasing order
-            assert (bus_df["bus"].values == torch.arange(len(bus_df))).all(), (
-                "Buses are not in increasing order"
-            )
-            # todo: we should remove this assert and store the bus idx in the tensors
-            # right now we need the increasing order for e.g. the predict step that uses torch.arange(n_nodes) to index the buses.
-            data["bus"].x = torch.tensor(bus_df[bus_features].values, dtype=torch.float)
-
-            # Generator nodes
-            gen_df = gen_groups.get_group(scenario).reset_index()
-            data["gen"].x = torch.tensor(gen_df[gen_features].values, dtype=torch.float)
-            gen_df["gen_index"] = gen_df.index  # Use actual index as generator ID
-            # todo: change this to instead use the generator id as the index
-
-            data["bus"].y = data["bus"].x[:, : (VA_H + 1)].clone()
-            data["gen"].y = data["gen"].x[:, : (PG_H + 1)].clone()
-
-            # Bus-Bus edges
-            branch_df = branch_groups.get_group(scenario)
-
-            forward_edges = torch.tensor(
-                branch_df[["from_bus", "to_bus"]].values.T,
-                dtype=torch.long,
-            )
-            forward_edge_attr = torch.tensor(
-                branch_df[forward_branch_features].values,
-                dtype=torch.float,
-            )
-
-            reverse_edges = torch.tensor(
-                branch_df[["to_bus", "from_bus"]].values.T,
-                dtype=torch.long,
-            )
-            reverse_edge_attr = torch.tensor(
-                branch_df[reverse_branch_features].values,
-                dtype=torch.float,
-            )
-
-            edge_index = torch.cat([forward_edges, reverse_edges], dim=1)
-            edge_attr = torch.cat([forward_edge_attr, reverse_edge_attr], dim=0)
-
-            forward_targets = torch.tensor(
-                branch_df[["pf", "qf"]].values,
-                dtype=torch.float,
-            )
-            reverse_targets = torch.tensor(
-                branch_df[["pt", "qt"]].values,
-                dtype=torch.float,
-            )
-            edge_y = torch.cat([forward_targets, reverse_targets], dim=0)
-
-            data["bus", "connects", "bus"].edge_index = edge_index
-            data["bus", "connects", "bus"].edge_attr = edge_attr
-            data["bus", "connects", "bus"].y = edge_y
-
-            # Gen-Bus and Bus-Gen edges
-            data["gen", "connected_to", "bus"].edge_index = torch.tensor(
-                gen_df[["gen_index", "bus"]].values.T,
-                dtype=torch.long,
-            )
-            data["bus", "connected_to", "gen"].edge_index = torch.tensor(
-                gen_df[["bus", "gen_index"]].values.T,
-                dtype=torch.long,
-            )
-
-            data["scenario_id"] = torch.tensor([scenario], dtype=torch.long)
-
-            # Save graph
-            torch.save(
-                data.to_dict(),
-                osp.join(self.processed_dir, f"data_index_{scenario}.pt"),
+            self._build_and_save_scenario(
+                scenario,
+                bus_groups.get_group(scenario),
+                gen_groups.get_group(scenario),
+                branch_groups.get_group(scenario),
             )
 
         with open(osp.join(self.processed_dir, self.processed_done_file), "w") as f:
             f.write("done")
+
+    _PARTITION_PREFIX = "scenario_partition="
+
+    def _partition_dir(self, table: str, partition_val: int) -> str:
+        """Path to a single Hive partition directory for a raw table."""
+        return osp.join(
+            self.raw_dir, table, f"{self._PARTITION_PREFIX}{partition_val}"
+        )
+
+    def _detect_partitions(self) -> list[int] | None:
+        """Return sorted scenario_partition values when all three tables are Hive-partitioned, else None."""
+        for table in self.raw_file_names:
+            table_path = osp.join(self.raw_dir, table)
+            if not osp.isdir(table_path):
+                return None
+            has_partition_dirs = any(
+                d.startswith(self._PARTITION_PREFIX) for d in os.listdir(table_path)
+            )
+            if not has_partition_dirs:
+                return None
+        bus_path = osp.join(self.raw_dir, "bus_data.parquet")
+        return sorted(
+            int(d[len(self._PARTITION_PREFIX):])
+            for d in os.listdir(bus_path)
+            if d.startswith(self._PARTITION_PREFIX)
+        )
+
+    def _process_streaming(self, partitions: list[int]) -> None:
+        """Build the scenario cache by reading one Hive partition at a time."""
+        done_path = osp.join(self.processed_dir, self.processed_done_file)
+        if osp.exists(done_path):
+            print("Processed files already exist. Skipping processing.")
+            return
+
+        print(f"Streaming {len(partitions)} partitions...")
+        load_scenarios: dict[int, int] = {}
+        for partition_val in tqdm(partitions, desc="Processing partitions"):
+            bus_data = pd.read_parquet(
+                self._partition_dir("bus_data.parquet", partition_val)
+            )
+            gen_data = pd.read_parquet(
+                self._partition_dir("gen_data.parquet", partition_val)
+            )
+            branch_data = pd.read_parquet(
+                self._partition_dir("branch_data.parquet", partition_val)
+            )
+
+            if "load_scenario_idx" in bus_data.columns:
+                first_idx = bus_data.groupby("scenario")["load_scenario_idx"].first()
+                load_scenarios.update(first_idx.to_dict())
+
+            agg_gen = (
+                gen_data.groupby(["scenario", "bus"])[["min_q_mvar", "max_q_mvar"]]
+                .sum()
+                .reset_index()
+            )
+            bus_data = bus_data.merge(agg_gen, on=["scenario", "bus"], how="left").fillna(0)
+
+            bus_groups = bus_data.groupby("scenario")
+            gen_groups = gen_data.groupby("scenario")
+            branch_groups = branch_data.groupby("scenario")
+
+            for scenario in bus_data["scenario"].unique():
+                if osp.exists(osp.join(self.processed_dir, f"data_index_{scenario}.pt")):
+                    continue
+                if scenario not in gen_groups.groups or scenario not in branch_groups.groups:
+                    raise ValueError(
+                        f"Scenario {scenario} is missing generator or branch data."
+                    )
+                self._build_and_save_scenario(
+                    scenario,
+                    bus_groups.get_group(scenario),
+                    gen_groups.get_group(scenario),
+                    branch_groups.get_group(scenario),
+                )
+
+        if load_scenarios:
+            ordered = [load_scenarios[s] for s in sorted(load_scenarios)]
+            torch.save(
+                torch.tensor(ordered),
+                osp.join(self.processed_dir, "load_scenarios.pt"),
+            )
+
+        with open(done_path, "w") as f:
+            f.write("done")
+
+    def _build_and_save_scenario(
+        self,
+        scenario: int,
+        bus_df: pd.DataFrame,
+        gen_df: pd.DataFrame,
+        branch_df: pd.DataFrame,
+    ) -> None:
+        """Build and persist one scenario's heterogeneous graph to disk."""
+        bus_features = [
+            "Pd", "Qd", "Qg", "Vm", "Va", "PQ", "PV", "REF",
+            "min_vm_pu", "max_vm_pu", "min_q_mvar", "max_q_mvar",
+            "GS", "BS", "vn_kv",
+        ]
+        gen_features = [
+            "p_mw", "min_p_mw", "max_p_mw",
+            "cp0_eur", "cp1_eur_per_mw", "cp2_eur_per_mw2",
+            "in_service",
+        ]
+        common_branch_features = ["tap", "ang_min", "ang_max", "rate_a", "br_status"]
+        forward_branch_features = [
+            "pf", "qf", "Yff_r", "Yff_i", "Yft_r", "Yft_i",
+        ] + common_branch_features
+        reverse_branch_features = [
+            "pt", "qt", "Ytt_r", "Ytt_i", "Ytf_r", "Ytf_i",
+        ] + common_branch_features
+
+        assert (
+            bus_df["bus"].values == torch.arange(len(bus_df))
+        ).all(), "Buses are not in increasing order"
+
+        data = HeteroData()
+
+        # Bus nodes
+        data["bus"].x = torch.tensor(bus_df[bus_features].values, dtype=torch.float)
+
+        # Generator nodes
+        gen_df = gen_df.reset_index()
+        data["gen"].x = torch.tensor(gen_df[gen_features].values, dtype=torch.float)
+        gen_df["gen_index"] = gen_df.index
+
+        data["bus"].y = data["bus"].x[:, : (VA_H + 1)].clone()
+        data["gen"].y = data["gen"].x[:, : (PG_H + 1)].clone()
+
+        # Bus-Bus edges
+        forward_edges = torch.tensor(
+            branch_df[["from_bus", "to_bus"]].values.T,
+            dtype=torch.long,
+        )
+        forward_edge_attr = torch.tensor(
+            branch_df[forward_branch_features].values,
+            dtype=torch.float,
+        )
+        reverse_edges = torch.tensor(
+            branch_df[["to_bus", "from_bus"]].values.T,
+            dtype=torch.long,
+        )
+        reverse_edge_attr = torch.tensor(
+            branch_df[reverse_branch_features].values,
+            dtype=torch.float,
+        )
+
+        edge_index = torch.cat([forward_edges, reverse_edges], dim=1)
+        edge_attr = torch.cat([forward_edge_attr, reverse_edge_attr], dim=0)
+
+        forward_targets = torch.tensor(
+            branch_df[["pf", "qf"]].values,
+            dtype=torch.float,
+        )
+        reverse_targets = torch.tensor(
+            branch_df[["pt", "qt"]].values,
+            dtype=torch.float,
+        )
+        edge_y = torch.cat([forward_targets, reverse_targets], dim=0)
+
+        data["bus", "connects", "bus"].edge_index = edge_index
+        data["bus", "connects", "bus"].edge_attr = edge_attr
+        data["bus", "connects", "bus"].y = edge_y
+
+        # Gen-Bus and Bus-Gen edges
+        data["gen", "connected_to", "bus"].edge_index = torch.tensor(
+            gen_df[["gen_index", "bus"]].values.T,
+            dtype=torch.long,
+        )
+        data["bus", "connected_to", "gen"].edge_index = torch.tensor(
+            gen_df[["bus", "gen_index"]].values.T,
+            dtype=torch.long,
+        )
+
+        data["scenario_id"] = torch.tensor([scenario], dtype=torch.long)
+
+        torch.save(
+            data.to_dict(),
+            osp.join(self.processed_dir, f"data_index_{scenario}.pt"),
+        )
 
     def len(self):
         if self.length is None:

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -184,6 +184,8 @@ class HeteroGridDatasetDisk(Dataset):
             ValueError: If a scenario id appears in more than one partition,
                 violating the datakit invariant that each scenario belongs to
                 exactly one scenario_partition.
+            ValueError: If the accumulated scenario ids across all partitions
+                are not a contiguous 0..N-1 range.
         """
         done_path = osp.join(self.processed_dir, self.processed_done_file)
         if osp.exists(done_path):
@@ -261,6 +263,18 @@ class HeteroGridDatasetDisk(Dataset):
                     gen_groups.get_group(scenario),
                     branch_groups.get_group(scenario),
                 )
+
+        # Mirror the legacy contiguity assertion: predict-step indexing
+        # relies on scenario ids forming a complete 0..N-1 range.
+        n = len(seen_scenarios)
+        actual_min = min(seen_scenarios)
+        actual_max = max(seen_scenarios)
+        if actual_min != 0 or actual_max != n - 1:
+            raise ValueError(
+                f"Scenario ids are not contiguous integers from 0 to {n - 1}. "
+                f"Found min={actual_min}, max={actual_max}, count={n}. "
+                f"Ensure no scenarios are missing from your partitioned data."
+            )
 
         if load_scenarios:
             ordered = [load_scenarios[s] for s in sorted(load_scenarios)]

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -157,22 +157,47 @@ class HeteroGridDatasetDisk(Dataset):
         return osp.join(self.raw_dir, table, f"{self._PARTITION_PREFIX}{partition_val}")
 
     def _detect_partitions(self) -> list[int] | None:
-        """Return sorted scenario_partition values when all three tables are Hive-partitioned, else None."""
+        """Return sorted scenario_partition values when all three tables are Hive-partitioned, else None.
+
+        Returns:
+            Sorted list of partition integers when all three tables expose the same
+            scenario_partition Hive layout, or None when at least one table is flat.
+
+        Raises:
+            ValueError: If all tables are partitioned but their partition sets differ,
+                indicating a data-preparation inconsistency that would cause a silent
+                read error later in streaming.
+        """
+        partition_sets: dict[str, set[int]] = {}
         for table in self.raw_file_names:
             table_path = osp.join(self.raw_dir, table)
             if not osp.isdir(table_path):
                 return None
-            has_partition_dirs = any(
-                d.startswith(self._PARTITION_PREFIX) for d in os.listdir(table_path)
-            )
-            if not has_partition_dirs:
+            parts = {
+                int(d[len(self._PARTITION_PREFIX) :])
+                for d in os.listdir(table_path)
+                if d.startswith(self._PARTITION_PREFIX)
+            }
+            if not parts:
                 return None
-        bus_path = osp.join(self.raw_dir, "bus_data.parquet")
-        return sorted(
-            int(d[len(self._PARTITION_PREFIX) :])
-            for d in os.listdir(bus_path)
-            if d.startswith(self._PARTITION_PREFIX)
-        )
+            partition_sets[table] = parts
+
+        reference_table = self.raw_file_names[0]
+        reference = partition_sets[reference_table]
+        mismatches = {t: p for t, p in partition_sets.items() if p != reference}
+        if mismatches:
+            details = ", ".join(
+                f"{t}={sorted(p)}" for t, p in mismatches.items()
+            )
+            raise ValueError(
+                f"Hive partition sets are inconsistent across tables. "
+                f"{reference_table} has partitions {sorted(reference)}, "
+                f"but the following tables differ: {details}. "
+                f"Re-generate your partitioned data so all tables share the same "
+                f"scenario_partition values."
+            )
+
+        return sorted(reference)
 
     def _process_streaming(self, partitions: list[int]) -> None:
         """Build the scenario cache by reading one Hive partition at a time.

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -40,7 +40,7 @@ class HeteroGridDatasetDisk(Dataset):
         if stream_partitions not in _VALID:
             raise ValueError(
                 f"stream_partitions={stream_partitions!r} is not valid; "
-                f"choose one of {sorted(_VALID)}"
+                f"choose one of {sorted(_VALID)}",
             )
         self.stream_partitions = stream_partitions
         self.data_normalizer = data_normalizer
@@ -76,7 +76,7 @@ class HeteroGridDatasetDisk(Dataset):
             if partitions is None:
                 raise RuntimeError(
                     f"stream_partitions='on' requires Hive-partitioned parquet, "
-                    f"but detected flat files in {self.raw_dir!r}. Use 'auto' or 'off'."
+                    f"but detected flat files in {self.raw_dir!r}. Use 'auto' or 'off'.",
                 )
             return self._process_streaming(partitions)
 
@@ -137,7 +137,7 @@ class HeteroGridDatasetDisk(Dataset):
                 or scenario not in branch_groups.groups
             ):
                 raise ValueError(
-                    f"Scenario {scenario} is missing generator or branch data."
+                    f"Scenario {scenario} is missing generator or branch data.",
                 )
 
             self._build_and_save_scenario(
@@ -154,9 +154,7 @@ class HeteroGridDatasetDisk(Dataset):
 
     def _partition_dir(self, table: str, partition_val: int) -> str:
         """Path to a single Hive partition directory for a raw table."""
-        return osp.join(
-            self.raw_dir, table, f"{self._PARTITION_PREFIX}{partition_val}"
-        )
+        return osp.join(self.raw_dir, table, f"{self._PARTITION_PREFIX}{partition_val}")
 
     def _detect_partitions(self) -> list[int] | None:
         """Return sorted scenario_partition values when all three tables are Hive-partitioned, else None."""
@@ -171,7 +169,7 @@ class HeteroGridDatasetDisk(Dataset):
                 return None
         bus_path = osp.join(self.raw_dir, "bus_data.parquet")
         return sorted(
-            int(d[len(self._PARTITION_PREFIX):])
+            int(d[len(self._PARTITION_PREFIX) :])
             for d in os.listdir(bus_path)
             if d.startswith(self._PARTITION_PREFIX)
         )
@@ -187,13 +185,13 @@ class HeteroGridDatasetDisk(Dataset):
         load_scenarios: dict[int, int] = {}
         for partition_val in tqdm(partitions, desc="Processing partitions"):
             bus_data = pd.read_parquet(
-                self._partition_dir("bus_data.parquet", partition_val)
+                self._partition_dir("bus_data.parquet", partition_val),
             )
             gen_data = pd.read_parquet(
-                self._partition_dir("gen_data.parquet", partition_val)
+                self._partition_dir("gen_data.parquet", partition_val),
             )
             branch_data = pd.read_parquet(
-                self._partition_dir("branch_data.parquet", partition_val)
+                self._partition_dir("branch_data.parquet", partition_val),
             )
 
             if "load_scenario_idx" in bus_data.columns:
@@ -205,18 +203,27 @@ class HeteroGridDatasetDisk(Dataset):
                 .sum()
                 .reset_index()
             )
-            bus_data = bus_data.merge(agg_gen, on=["scenario", "bus"], how="left").fillna(0)
+            bus_data = bus_data.merge(
+                agg_gen,
+                on=["scenario", "bus"],
+                how="left",
+            ).fillna(0)
 
             bus_groups = bus_data.groupby("scenario")
             gen_groups = gen_data.groupby("scenario")
             branch_groups = branch_data.groupby("scenario")
 
             for scenario in bus_data["scenario"].unique():
-                if osp.exists(osp.join(self.processed_dir, f"data_index_{scenario}.pt")):
+                if osp.exists(
+                    osp.join(self.processed_dir, f"data_index_{scenario}.pt"),
+                ):
                     continue
-                if scenario not in gen_groups.groups or scenario not in branch_groups.groups:
+                if (
+                    scenario not in gen_groups.groups
+                    or scenario not in branch_groups.groups
+                ):
                     raise ValueError(
-                        f"Scenario {scenario} is missing generator or branch data."
+                        f"Scenario {scenario} is missing generator or branch data.",
                     )
                 self._build_and_save_scenario(
                     scenario,
@@ -244,26 +251,52 @@ class HeteroGridDatasetDisk(Dataset):
     ) -> None:
         """Build and persist one scenario's heterogeneous graph to disk."""
         bus_features = [
-            "Pd", "Qd", "Qg", "Vm", "Va", "PQ", "PV", "REF",
-            "min_vm_pu", "max_vm_pu", "min_q_mvar", "max_q_mvar",
-            "GS", "BS", "vn_kv",
+            "Pd",
+            "Qd",
+            "Qg",
+            "Vm",
+            "Va",
+            "PQ",
+            "PV",
+            "REF",
+            "min_vm_pu",
+            "max_vm_pu",
+            "min_q_mvar",
+            "max_q_mvar",
+            "GS",
+            "BS",
+            "vn_kv",
         ]
         gen_features = [
-            "p_mw", "min_p_mw", "max_p_mw",
-            "cp0_eur", "cp1_eur_per_mw", "cp2_eur_per_mw2",
+            "p_mw",
+            "min_p_mw",
+            "max_p_mw",
+            "cp0_eur",
+            "cp1_eur_per_mw",
+            "cp2_eur_per_mw2",
             "in_service",
         ]
         common_branch_features = ["tap", "ang_min", "ang_max", "rate_a", "br_status"]
         forward_branch_features = [
-            "pf", "qf", "Yff_r", "Yff_i", "Yft_r", "Yft_i",
+            "pf",
+            "qf",
+            "Yff_r",
+            "Yff_i",
+            "Yft_r",
+            "Yft_i",
         ] + common_branch_features
         reverse_branch_features = [
-            "pt", "qt", "Ytt_r", "Ytt_i", "Ytf_r", "Ytf_i",
+            "pt",
+            "qt",
+            "Ytt_r",
+            "Ytt_i",
+            "Ytf_r",
+            "Ytf_i",
         ] + common_branch_features
 
-        assert (
-            bus_df["bus"].values == torch.arange(len(bus_df))
-        ).all(), "Buses are not in increasing order"
+        assert (bus_df["bus"].values == torch.arange(len(bus_df))).all(), (
+            "Buses are not in increasing order"
+        )
 
         data = HeteroData()
 

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -186,15 +186,13 @@ class HeteroGridDatasetDisk(Dataset):
         reference = partition_sets[reference_table]
         mismatches = {t: p for t, p in partition_sets.items() if p != reference}
         if mismatches:
-            details = ", ".join(
-                f"{t}={sorted(p)}" for t, p in mismatches.items()
-            )
+            details = ", ".join(f"{t}={sorted(p)}" for t, p in mismatches.items())
             raise ValueError(
                 f"Hive partition sets are inconsistent across tables. "
                 f"{reference_table} has partitions {sorted(reference)}, "
                 f"but the following tables differ: {details}. "
                 f"Re-generate your partitioned data so all tables share the same "
-                f"scenario_partition values."
+                f"scenario_partition values.",
             )
 
         return sorted(reference)
@@ -243,7 +241,7 @@ class HeteroGridDatasetDisk(Dataset):
                     f"Each scenario must be fully contained within a single "
                     f"scenario_partition so that per-partition Q-limit aggregation "
                     f"(agg_gen) is equivalent to the legacy whole-dataset merge. "
-                    f"Re-partition your data so no scenario spans two partitions."
+                    f"Re-partition your data so no scenario spans two partitions.",
                 )
             for s in partition_scenarios:
                 seen_scenarios[s] = partition_val
@@ -298,7 +296,7 @@ class HeteroGridDatasetDisk(Dataset):
             raise ValueError(
                 f"Scenario ids are not contiguous integers from 0 to {n - 1}. "
                 f"Found min={actual_min}, max={actual_max}, count={n}. "
-                f"Ensure no scenarios are missing from your partitioned data."
+                f"Ensure no scenarios are missing from your partitioned data.",
             )
 
         if load_scenarios:

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -175,7 +175,16 @@ class HeteroGridDatasetDisk(Dataset):
         )
 
     def _process_streaming(self, partitions: list[int]) -> None:
-        """Build the scenario cache by reading one Hive partition at a time."""
+        """Build the scenario cache by reading one Hive partition at a time.
+
+        Args:
+            partitions: Sorted list of scenario_partition values to process.
+
+        Raises:
+            ValueError: If a scenario id appears in more than one partition,
+                violating the datakit invariant that each scenario belongs to
+                exactly one scenario_partition.
+        """
         done_path = osp.join(self.processed_dir, self.processed_done_file)
         if osp.exists(done_path):
             print("Processed files already exist. Skipping processing.")
@@ -183,6 +192,9 @@ class HeteroGridDatasetDisk(Dataset):
 
         print(f"Streaming {len(partitions)} partitions...")
         load_scenarios: dict[int, int] = {}
+        # Maps scenario id → partition it was first seen in, to enforce the
+        # datakit invariant: every scenario lives in exactly one partition.
+        seen_scenarios: dict[int, int] = {}
         for partition_val in tqdm(partitions, desc="Processing partitions"):
             bus_data = pd.read_parquet(
                 self._partition_dir("bus_data.parquet", partition_val),
@@ -194,10 +206,28 @@ class HeteroGridDatasetDisk(Dataset):
                 self._partition_dir("branch_data.parquet", partition_val),
             )
 
+            partition_scenarios = set(int(s) for s in bus_data["scenario"].unique())
+            duplicates = partition_scenarios & seen_scenarios.keys()
+            if duplicates:
+                offender = min(duplicates)
+                raise ValueError(
+                    f"Scenario {offender} appears in both partition "
+                    f"{seen_scenarios[offender]} and partition {partition_val}. "
+                    f"Each scenario must be fully contained within a single "
+                    f"scenario_partition so that per-partition Q-limit aggregation "
+                    f"(agg_gen) is equivalent to the legacy whole-dataset merge. "
+                    f"Re-partition your data so no scenario spans two partitions."
+                )
+            for s in partition_scenarios:
+                seen_scenarios[s] = partition_val
+
             if "load_scenario_idx" in bus_data.columns:
                 first_idx = bus_data.groupby("scenario")["load_scenario_idx"].first()
                 load_scenarios.update(first_idx.to_dict())
 
+            # Invariant: every scenario's rows are fully contained in this
+            # partition, so summing Q-limits here equals the legacy whole-dataset
+            # groupby sum.
             agg_gen = (
                 gen_data.groupby(["scenario", "bus"])[["min_q_mvar", "max_q_mvar"]]
                 .sum()

--- a/tests/config/SE_simulate_measurements.yaml
+++ b/tests/config/SE_simulate_measurements.yaml
@@ -34,6 +34,7 @@ data:
   test_ratio: 0.1
   val_ratio: 0.1
   workers: 1
+  stream_partitions: auto
 model:
   attention_head: 8
   edge_dim: 10

--- a/tests/config/datamodule_test_base_config.yaml
+++ b/tests/config/datamodule_test_base_config.yaml
@@ -34,6 +34,7 @@ data:
   val_ratio: 0.1
   workers: 1
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 2
   edge_dim: 10

--- a/tests/config/datamodule_test_base_config2.yaml
+++ b/tests/config/datamodule_test_base_config2.yaml
@@ -19,6 +19,7 @@ data:
   val_ratio: 0.1
   workers: 1
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 2
   edge_dim: 10

--- a/tests/config/datamodule_test_base_config3.yaml
+++ b/tests/config/datamodule_test_base_config3.yaml
@@ -34,6 +34,7 @@ data:
   val_ratio: 0.1
   workers: 1
   split_by_load_scenario_idx: true
+  stream_partitions: auto
 model:
   attention_head: 2
   edge_dim: 10

--- a/tests/test_streaming_partitions.py
+++ b/tests/test_streaming_partitions.py
@@ -266,13 +266,14 @@ def test_scenario_spanning_two_partitions_raises(tmp_path):
     for table in _TABLES:
         part0_dir = osp.join(raw, table, "scenario_partition=0")
         part1_dir = osp.join(raw, table, "scenario_partition=1")
-        src_file = next(
-            f for f in os.listdir(part0_dir) if f.startswith("scenario_0.")
-        )
+        src_file = next(f for f in os.listdir(part0_dir) if f.startswith("scenario_0."))
         df = pd.read_parquet(osp.join(part0_dir, src_file))
         df.to_parquet(osp.join(part1_dir, "scenario_0_duplicate.parquet"), index=False)
 
-    with pytest.raises(ValueError, match=r"Scenario 0 appears in both partition 0 and partition 1"):
+    with pytest.raises(
+        ValueError,
+        match=r"Scenario 0 appears in both partition 0 and partition 1",
+    ):
         _build(root, "on")
 
 
@@ -316,5 +317,8 @@ def test_detect_partitions_raises_on_mismatched_partition_sets(tmp_path):
     # Remove partition 1 from branch only — bus and gen still have {0, 1}.
     shutil.rmtree(osp.join(raw, "branch_data.parquet", "scenario_partition=1"))
 
-    with pytest.raises(ValueError, match=r"inconsistent across tables.*branch_data\.parquet"):
+    with pytest.raises(
+        ValueError,
+        match=r"inconsistent across tables.*branch_data\.parquet",
+    ):
         _build(root, "auto")

--- a/tests/test_streaming_partitions.py
+++ b/tests/test_streaming_partitions.py
@@ -1,0 +1,185 @@
+"""Tests for Hive-partition streaming in HeteroGridDatasetDisk.
+
+The central guarantee is that streaming changes *memory usage*, not *results*:
+processing the same source data laid out flat vs. Hive-partitioned must produce
+identical on-disk output. The remaining tests pin the mode contracts
+(auto/on/off) and the partition-detection boundaries.
+"""
+
+import os
+import os.path as osp
+import shutil
+
+import pandas as pd
+import pytest
+import torch
+
+from gridfm_graphkit.datasets.powergrid_hetero_dataset import HeteroGridDatasetDisk
+
+_SRC_RAW = "tests/data/case14_ieee/raw"
+_TABLES = ["bus_data.parquet", "gen_data.parquet", "branch_data.parquet"]
+_N_SCENARIOS = 6  # subset of the 72-scenario fixture to keep the tests fast
+_SCEN_PER_PARTITION = 3  # -> partitions {0, 1} for the subset above
+
+
+def _subset(df: pd.DataFrame) -> pd.DataFrame:
+    return df[df["scenario"] < _N_SCENARIOS].copy()
+
+
+def _write_flat(root: str) -> None:
+    """Write the subset as single flat parquet files under ``root/raw``."""
+    raw = osp.join(root, "raw")
+    os.makedirs(raw, exist_ok=True)
+    for table in _TABLES:
+        _subset(pd.read_parquet(osp.join(_SRC_RAW, table))).to_parquet(
+            osp.join(raw, table), index=False
+        )
+
+
+def _write_partitioned(root: str) -> None:
+    """Write the subset as Hive-partitioned parquet under ``root/raw``."""
+    raw = osp.join(root, "raw")
+    for table in _TABLES:
+        df = _subset(pd.read_parquet(osp.join(_SRC_RAW, table)))
+        # Drop any pre-existing partition column so pyarrow does not see it
+        # both in the file and re-derived from the directory name.
+        df = df.drop(columns=["scenario_partition"], errors="ignore")
+        for scenario, group in df.groupby("scenario"):
+            part = int(scenario) // _SCEN_PER_PARTITION
+            part_dir = osp.join(raw, table, f"scenario_partition={part}")
+            os.makedirs(part_dir, exist_ok=True)
+            out = osp.join(part_dir, f"scenario_{int(scenario)}.parquet")
+            group.to_parquet(out, index=False)
+
+
+def _build(root: str, stream_partitions: str) -> HeteroGridDatasetDisk:
+    # data_normalizer is only used at access time (get()), not during process().
+    return HeteroGridDatasetDisk(
+        root=root,
+        data_normalizer=None,
+        stream_partitions=stream_partitions,
+    )
+
+
+def _load_graphs(processed_dir: str) -> dict[str, dict]:
+    graphs = {}
+    for name in os.listdir(processed_dir):
+        if name.startswith("data_index_") and name.endswith(".pt"):
+            graphs[name] = torch.load(
+                osp.join(processed_dir, name), weights_only=True
+            )
+    return graphs
+
+
+def _assert_graphs_equal(a: dict[str, dict], b: dict[str, dict]) -> None:
+    assert set(a) == set(b), "different set of scenario graphs produced"
+    for name in a:
+        _assert_value_equal(a[name], b[name], name)
+
+
+def _assert_value_equal(va, vb, path: str) -> None:
+    if isinstance(va, torch.Tensor):
+        assert isinstance(vb, torch.Tensor), f"{path}: type mismatch"
+        assert torch.equal(va, vb), f"{path}: tensor mismatch"
+    elif isinstance(va, dict):
+        assert isinstance(vb, dict), f"{path}: type mismatch"
+        assert set(va) == set(vb), f"{path}: different keys"
+        for key in va:
+            _assert_value_equal(va[key], vb[key], f"{path}.{key}")
+    else:
+        assert va == vb, f"{path}: value mismatch"
+
+
+def test_streaming_matches_flat(tmp_path):
+    """Streaming and flat processing must yield identical scenario graphs."""
+    flat_root = str(tmp_path / "flat")
+    part_root = str(tmp_path / "partitioned")
+    _write_flat(flat_root)
+    _write_partitioned(part_root)
+
+    _build(flat_root, "off")
+    _build(part_root, "on")
+
+    flat_graphs = _load_graphs(osp.join(flat_root, "processed"))
+    part_graphs = _load_graphs(osp.join(part_root, "processed"))
+
+    assert len(flat_graphs) == _N_SCENARIOS
+    _assert_graphs_equal(flat_graphs, part_graphs)
+
+
+def test_streaming_matches_flat_load_scenarios(tmp_path):
+    """load_scenarios.pt must be identical between the two paths."""
+    flat_root = str(tmp_path / "flat")
+    part_root = str(tmp_path / "partitioned")
+    _write_flat(flat_root)
+    _write_partitioned(part_root)
+
+    _build(flat_root, "off")
+    _build(part_root, "on")
+
+    flat_ls = torch.load(
+        osp.join(flat_root, "processed", "load_scenarios.pt"), weights_only=True
+    )
+    part_ls = torch.load(
+        osp.join(part_root, "processed", "load_scenarios.pt"), weights_only=True
+    )
+    assert torch.equal(flat_ls, part_ls)
+
+
+def test_auto_uses_streaming_when_partitioned(tmp_path):
+    """auto mode on partitioned data produces the full set of graphs."""
+    root = str(tmp_path / "auto_part")
+    _write_partitioned(root)
+    ds = _build(root, "auto")
+    assert ds._detect_partitions() == [0, 1]
+    assert len(_load_graphs(osp.join(root, "processed"))) == _N_SCENARIOS
+
+
+def test_auto_uses_legacy_when_flat(tmp_path):
+    """auto mode on flat data detects no partitions and still processes."""
+    root = str(tmp_path / "auto_flat")
+    _write_flat(root)
+    ds = _build(root, "auto")
+    assert ds._detect_partitions() is None
+    assert len(_load_graphs(osp.join(root, "processed"))) == _N_SCENARIOS
+
+
+def test_on_without_partitions_raises(tmp_path):
+    """stream_partitions='on' must fail loudly when data is flat."""
+    root = str(tmp_path / "on_flat")
+    _write_flat(root)
+    with pytest.raises(RuntimeError, match="requires Hive-partitioned"):
+        _build(root, "on")
+
+
+def test_off_ignores_partitions(tmp_path):
+    """stream_partitions='off' uses the legacy path even when partitioned."""
+    root = str(tmp_path / "off_part")
+    _write_partitioned(root)
+    ds = _build(root, "off")
+    # Partitions physically exist, but 'off' still builds every scenario graph.
+    assert ds._detect_partitions() == [0, 1]
+    assert len(_load_graphs(osp.join(root, "processed"))) == _N_SCENARIOS
+
+
+def test_invalid_mode_raises(tmp_path):
+    """An unknown stream_partitions value is rejected before any processing."""
+    root = str(tmp_path / "bad")
+    _write_flat(root)
+    with pytest.raises(ValueError, match="stream_partitions"):
+        _build(root, "sometimes")
+
+
+@pytest.mark.parametrize("missing_table", _TABLES)
+def test_detect_partitions_requires_all_tables(tmp_path, missing_table):
+    """If any table is not partitioned, detection returns None (legacy path)."""
+    root = str(tmp_path / "mixed")
+    _write_partitioned(root)
+    # Flatten a single table so the layout is inconsistent.
+    raw = osp.join(root, "raw")
+    df = _subset(pd.read_parquet(osp.join(_SRC_RAW, missing_table)))
+    shutil.rmtree(osp.join(raw, missing_table))
+    df.to_parquet(osp.join(raw, missing_table), index=False)
+
+    ds = _build(root, "auto")
+    assert ds._detect_partitions() is None

--- a/tests/test_streaming_partitions.py
+++ b/tests/test_streaming_partitions.py
@@ -274,3 +274,30 @@ def test_scenario_spanning_two_partitions_raises(tmp_path):
 
     with pytest.raises(ValueError, match=r"Scenario 0 appears in both partition 0 and partition 1"):
         _build(root, "on")
+
+
+def test_streaming_raises_on_noncontiguous_scenario_ids(tmp_path):
+    """Streaming must raise when scenario ids have a gap (e.g. 0,1,2,4,5 — missing 3).
+
+    The gap fixture is built by writing a valid partitioned layout and then
+    deleting scenario 3's files from all tables.  This leaves ids {0,1,2,4,5}:
+    min=0, max=5, count=5 → the contiguity check (max == count-1, i.e. 5==4) fails.
+    """
+    root = str(tmp_path / "gap")
+    _write_partitioned(root)
+    raw = osp.join(root, "raw")
+    for table in _TABLES:
+        gap_file = osp.join(raw, table, "scenario_partition=1", "scenario_3.parquet")
+        if osp.exists(gap_file):
+            os.remove(gap_file)
+
+    with pytest.raises(ValueError, match=r"max=5, count=5"):
+        _build(root, "on")
+
+
+def test_streaming_accepts_contiguous_scenario_ids(tmp_path):
+    """Streaming must not raise when scenario ids are a complete 0..N-1 range."""
+    root = str(tmp_path / "contiguous")
+    _write_partitioned(root)
+    _build(root, "on")
+    assert len(_load_graphs(osp.join(root, "processed"))) == _N_SCENARIOS

--- a/tests/test_streaming_partitions.py
+++ b/tests/test_streaming_partitions.py
@@ -246,3 +246,31 @@ def test_detect_partitions_requires_all_tables(tmp_path, missing_table):
 
     ds = _build(root, "auto")
     assert ds._detect_partitions() is None
+
+
+def test_scenario_spanning_two_partitions_raises(tmp_path):
+    """A scenario whose rows are split across two partitions must raise ValueError.
+
+    This guards the per-partition agg_gen Q-limit sum: if scenario X lives in
+    both partition 0 and partition 1, the sum is computed twice on partial data
+    and diverges from the legacy whole-dataset merge.  The guard must fire
+    before any .pt file is written for the offending scenario.
+    """
+    root = str(tmp_path / "split_scenario")
+    raw = osp.join(root, "raw")
+
+    # Write a valid partitioned layout first, then inject a copy of scenario 0
+    # into partition 1 so it spans two partitions.
+    _write_partitioned(root)
+
+    for table in _TABLES:
+        part0_dir = osp.join(raw, table, "scenario_partition=0")
+        part1_dir = osp.join(raw, table, "scenario_partition=1")
+        src_file = next(
+            f for f in os.listdir(part0_dir) if f.startswith("scenario_0.")
+        )
+        df = pd.read_parquet(osp.join(part0_dir, src_file))
+        df.to_parquet(osp.join(part1_dir, "scenario_0_duplicate.parquet"), index=False)
+
+    with pytest.raises(ValueError, match=r"Scenario 0 appears in both partition 0 and partition 1"):
+        _build(root, "on")

--- a/tests/test_streaming_partitions.py
+++ b/tests/test_streaming_partitions.py
@@ -301,3 +301,20 @@ def test_streaming_accepts_contiguous_scenario_ids(tmp_path):
     _write_partitioned(root)
     _build(root, "on")
     assert len(_load_graphs(osp.join(root, "processed"))) == _N_SCENARIOS
+
+
+def test_detect_partitions_raises_on_mismatched_partition_sets(tmp_path):
+    """_detect_partitions must raise early when all tables are partitioned but sets differ.
+
+    A mismatch (e.g. branch missing partition 1) would otherwise surface as a
+    confusing FileNotFoundError deep inside _process_streaming.
+    """
+    root = str(tmp_path / "mismatch")
+    _write_partitioned(root)
+    raw = osp.join(root, "raw")
+
+    # Remove partition 1 from branch only — bus and gen still have {0, 1}.
+    shutil.rmtree(osp.join(raw, "branch_data.parquet", "scenario_partition=1"))
+
+    with pytest.raises(ValueError, match=r"inconsistent across tables.*branch_data\.parquet"):
+        _build(root, "auto")

--- a/tests/test_streaming_partitions.py
+++ b/tests/test_streaming_partitions.py
@@ -1,3 +1,18 @@
+# Copyright 2026 GridFM Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 """Tests for Hive-partition streaming in HeteroGridDatasetDisk.
 
 The central guarantee is that streaming changes *memory usage*, not *results*:
@@ -33,7 +48,8 @@ def _write_flat(root: str) -> None:
     os.makedirs(raw, exist_ok=True)
     for table in _TABLES:
         _subset(pd.read_parquet(osp.join(_SRC_RAW, table))).to_parquet(
-            osp.join(raw, table), index=False
+            osp.join(raw, table),
+            index=False,
         )
 
 
@@ -66,9 +82,7 @@ def _load_graphs(processed_dir: str) -> dict[str, dict]:
     graphs = {}
     for name in os.listdir(processed_dir):
         if name.startswith("data_index_") and name.endswith(".pt"):
-            graphs[name] = torch.load(
-                osp.join(processed_dir, name), weights_only=True
-            )
+            graphs[name] = torch.load(osp.join(processed_dir, name), weights_only=True)
     return graphs
 
 
@@ -119,9 +133,7 @@ def test_scenario_graph_structure(tmp_path):
     root = str(tmp_path / "flat")
     _write_flat(root)
     _build(root, "off")
-    g = torch.load(
-        osp.join(root, "processed", "data_index_0.pt"), weights_only=True
-    )
+    g = torch.load(osp.join(root, "processed", "data_index_0.pt"), weights_only=True)
 
     bus, gen = g["bus"], g["gen"]
     bb = g[("bus", "connects", "bus")]
@@ -167,10 +179,12 @@ def test_streaming_matches_flat_load_scenarios(tmp_path):
     _build(part_root, "on")
 
     flat_ls = torch.load(
-        osp.join(flat_root, "processed", "load_scenarios.pt"), weights_only=True
+        osp.join(flat_root, "processed", "load_scenarios.pt"),
+        weights_only=True,
     )
     part_ls = torch.load(
-        osp.join(part_root, "processed", "load_scenarios.pt"), weights_only=True
+        osp.join(part_root, "processed", "load_scenarios.pt"),
+        weights_only=True,
     )
     assert torch.equal(flat_ls, part_ls)
 

--- a/tests/test_streaming_partitions.py
+++ b/tests/test_streaming_partitions.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 
 from gridfm_graphkit.datasets.powergrid_hetero_dataset import HeteroGridDatasetDisk
+from gridfm_graphkit.datasets.globals import VA_H, PG_H
 
 _SRC_RAW = "tests/data/case14_ieee/raw"
 _TABLES = ["bus_data.parquet", "gen_data.parquet", "branch_data.parquet"]
@@ -105,6 +106,54 @@ def test_streaming_matches_flat(tmp_path):
 
     assert len(flat_graphs) == _N_SCENARIOS
     _assert_graphs_equal(flat_graphs, part_graphs)
+
+
+def test_scenario_graph_structure(tmp_path):
+    """Pin the absolute structure of a built graph against the case14 fixture.
+
+    The equivalence test only proves flat == streaming; because both paths share
+    ``_build_and_save_scenario``, a fault in that shared builder would corrupt
+    both sides identically and still pass. These assertions check ground truth
+    (shapes, slice boundaries, edge mirroring) so builder faults are caught.
+    """
+    root = str(tmp_path / "flat")
+    _write_flat(root)
+    _build(root, "off")
+    g = torch.load(
+        osp.join(root, "processed", "data_index_0.pt"), weights_only=True
+    )
+
+    bus, gen = g["bus"], g["gen"]
+    bb = g[("bus", "connects", "bus")]
+    n_bus, n_gen = 14, 5
+    n_branch = 20
+
+    # Node feature blocks and target slice boundaries (kills VA_H/PG_H mutants).
+    assert bus["x"].shape == (n_bus, 15)
+    assert gen["x"].shape == (n_gen, 7)
+    assert bus["y"].shape == (n_bus, VA_H + 1)
+    assert gen["y"].shape == (n_gen, PG_H + 1)
+    assert torch.equal(bus["y"], bus["x"][:, : VA_H + 1])
+    assert torch.equal(gen["y"], gen["x"][:, : PG_H + 1])
+
+    # Directed edges = forward + reverse of every branch (kills cat/order mutants).
+    ei = bb["edge_index"]
+    assert ei.shape == (2, 2 * n_branch)
+    assert bb["edge_attr"].shape == (2 * n_branch, 11)
+    assert bb["y"].shape == (2 * n_branch, 2)
+    fwd, rev = ei[:, :n_branch], ei[:, n_branch:]
+    # Reverse half must mirror the forward half (kills from_bus/to_bus swaps).
+    assert torch.equal(rev[0], fwd[1])
+    assert torch.equal(rev[1], fwd[0])
+
+    # Generator connectivity is symmetric between the two directed edge sets.
+    g2b = g[("gen", "connected_to", "bus")]["edge_index"]
+    b2g = g[("bus", "connected_to", "gen")]["edge_index"]
+    assert g2b.shape == (2, n_gen)
+    assert torch.equal(g2b[0], b2g[1])
+    assert torch.equal(g2b[1], b2g[0])
+
+    assert int(g["_global_store"]["scenario_id"].item()) == 0
 
 
 def test_streaming_matches_flat_load_scenarios(tmp_path):


### PR DESCRIPTION
# Add memory-bounded streaming preprocessing for Hive-partitioned parquet

## Problem
`HeteroGridDatasetDisk` loads *processed* graphs lazily at access time, but the one-time `process()` step reads the **entire** `bus_data.parquet`, `gen_data.parquet`, and `branch_data.parquet` into memory (plus a scenario/bus aggregation merge) before building any scenario graphs. Peak RAM during preprocessing therefore scales with the *whole dataset*. For large runs (many scenarios × large grids) this can OOM before training starts, even though the eventual per-graph access pattern is already memory-friendly.

## What this changes
Adds an **optional** streaming preprocessing path that activates when the raw parquet is laid out as **Hive partitions** (`bus_data.parquet/scenario_partition=<n>/…`, likewise for gen/branch). Instead of reading everything up front, `process()` reads and builds **one partition at a time**, so peak preprocessing memory is bounded by the **largest single partition** rather than the full dataset.

Behavior is opt-out-safe:
- Both the legacy path and the streaming path build every graph through the **same** private method (`_build_and_save_scenario`), which is the sole owner of the feature/edge schema. The streaming path only changes *how much raw data is resident at once* — not how a graph is built — so processed output is identical.
- The streaming path is **resume-safe**: it skips any scenario whose `data_index_<n>.pt` already exists and only writes the `processed_raw_files.done` marker after all partitions complete, so an interrupted run continues cleanly.
- `load_scenarios.pt` is accumulated across partitions and written in scenario order, matching the flat path's output exactly.

## Interface
New `stream_partitions` option, threaded through the stack:
- `HeteroGridDatasetDisk(stream_partitions=...)` — validated in `__init__` (raises `ValueError` on anything other than `auto`/`on`/`off`).
- YAML `data.stream_partitions`, consumed by `LitGridHeteroDataModule`.
- CLI `--stream-partitions` on the `train`, `finetune`, `evaluate`, and `predict` subcommands (overrides the YAML value).

Modes:
- **`auto`** (default): stream if partitions are detected, otherwise use the existing flat-file path.
- **`on`**: require partitions; raises `RuntimeError` with a clear message if the raw dir is flat.
- **`off`**: force the legacy flat-file path even if partitions exist.

Partition detection (`_detect_partitions`) is conservative: it only reports partitions when **all three** tables are directories containing `scenario_partition=` subdirs; any inconsistency (e.g. one table left flat) falls back to the legacy path.

## Backward compatibility
Default `auto` + non-partitioned data = **byte-identical behavior to today**. No change to existing configs, data layouts, output filenames, or the processed on-disk format. Users who don't produce Hive-partitioned parquet are unaffected.

## Tests
Adds `tests/test_streaming_partitions.py` (11 tests, using the existing `case14_ieee` fixture):
- **Equivalence**: flat vs. streaming produce identical scenario graphs (deep tensor comparison) and identical `load_scenarios.pt`.
- **Absolute structure**: pins ground-truth shapes, target-slice boundaries (`VA_H`/`PG_H`), and forward/reverse edge mirroring of a built graph — so a fault in the shared builder is caught even though both paths share it.
- **Mode contracts**: `auto` streams when partitioned and falls back when flat; `on` raises without partitions; `off` ignores partitions; invalid mode rejected.
- **Detection boundary**: parametrized check that a single non-partitioned table disables streaming.

## Files changed
- `gridfm_graphkit/datasets/powergrid_hetero_dataset.py` — detection + streaming path + validation
- `gridfm_graphkit/datasets/hetero_powergrid_datamodule.py` — reads `data.stream_partitions`
- `gridfm_graphkit/cli.py` — CLI→config override
- `gridfm_graphkit/__main__.py` — `--stream-partitions` on the four subcommands
- `tests/test_streaming_partitions.py` — new test module