### PR TITLE
Fix: restore masked bus and branch limit columns in PF predict/test output

### DIFF
--- a/gridfm_graphkit/datasets/masking.py
+++ b/gridfm_graphkit/datasets/masking.py
@@ -221,12 +221,13 @@ class RemovePFMask(BaseTransform):
     """
 
     def forward(self, data):
-        data.x_dict["bus"][:, [MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV]] = (
-            data["bus"].static
-        )
-        data.edge_attr_dict[("bus", "connects", "bus")][:, [ANG_MIN, ANG_MAX, RATE_A]] = (
-            data[("bus", "connects", "bus")].static
-        )
+        data.x_dict["bus"][:, [MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV]] = data[
+            "bus"
+        ].static
+        data.edge_attr_dict[("bus", "connects", "bus")][
+            :,
+            [ANG_MIN, ANG_MAX, RATE_A],
+        ] = data[("bus", "connects", "bus")].static
         return data
 
 

--- a/gridfm_graphkit/datasets/masking.py
+++ b/gridfm_graphkit/datasets/masking.py
@@ -210,6 +210,26 @@ class AddOPFHeteroMask(BaseTransform):
         return data
 
 
+class RemovePFMask(BaseTransform):
+    """Restore static limit columns that were zeroed by AddPFHeteroMask.
+
+    Call this after inverse_transform() and inverse_output() so that bus and
+    branch limit values (MIN_VM, MAX_VM, MIN_QG, MAX_QG, VN_KV, ANG_MIN,
+    ANG_MAX, RATE_A) are correct for post-inference constraint evaluation.
+    The values are sourced from the ``.static`` attribute saved at dataset
+    build time, before any masking or normalisation ran.
+    """
+
+    def forward(self, data):
+        data.x_dict["bus"][:, [MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV]] = (
+            data["bus"].static
+        )
+        data.edge_attr_dict[("bus", "connects", "bus")][:, [ANG_MIN, ANG_MAX, RATE_A]] = (
+            data[("bus", "connects", "bus")].static
+        )
+        return data
+
+
 class BusToGenBroadcaster(MessagePassing):
     """Broadcast per-bus values to connected generators via graph propagation."""
 

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -378,20 +378,18 @@ class HeteroGridDatasetDisk(Dataset):
 
         data = HeteroData()
 
-            # Bus nodes
-            bus_df = bus_groups.get_group(scenario)
-            # assert that the buses are in increasing order
-            assert (bus_df["bus"].values == torch.arange(len(bus_df))).all(), (
-                "Buses are not in increasing order"
-            )
-            # todo: we should remove this assert and store the bus idx in the tensors
-            # right now we need the increasing order for e.g. the predict step that uses torch.arange(n_nodes) to index the buses.
-            data["bus"].x = torch.tensor(bus_df[bus_features].values, dtype=torch.float)
-            data["bus"].static = (
-                data["bus"]
-                .x[:, [MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV]]
-                .clone()
-            )
+        # Bus nodes
+        bus_df = bus_groups.get_group(scenario)
+        # assert that the buses are in increasing order
+        assert (bus_df["bus"].values == torch.arange(len(bus_df))).all(), (
+            "Buses are not in increasing order"
+        )
+        # todo: we should remove this assert and store the bus idx in the tensors
+        # right now we need the increasing order for e.g. the predict step that uses torch.arange(n_nodes) to index the buses.
+        data["bus"].x = torch.tensor(bus_df[bus_features].values, dtype=torch.float)
+        data["bus"].static = (
+            data["bus"].x[:, [MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV]].clone()
+        )
 
         # Generator nodes
         gen_df = gen_df.reset_index()
@@ -432,13 +430,13 @@ class HeteroGridDatasetDisk(Dataset):
         )
         edge_y = torch.cat([forward_targets, reverse_targets], dim=0)
 
-            data["bus", "connects", "bus"].edge_index = edge_index
-            data["bus", "connects", "bus"].edge_attr = edge_attr
-            data["bus", "connects", "bus"].static = edge_attr[
-                :,
-                [ANG_MIN, ANG_MAX, RATE_A],
-            ].clone()
-            data["bus", "connects", "bus"].y = edge_y
+        data["bus", "connects", "bus"].edge_index = edge_index
+        data["bus", "connects", "bus"].edge_attr = edge_attr
+        data["bus", "connects", "bus"].static = edge_attr[
+            :,
+            [ANG_MIN, ANG_MAX, RATE_A],
+        ].clone()
+        data["bus", "connects", "bus"].y = edge_y
 
         # Gen-Bus and Bus-Gen edges
         data["gen", "connected_to", "bus"].edge_index = torch.tensor(

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -379,13 +379,6 @@ class HeteroGridDatasetDisk(Dataset):
         data = HeteroData()
 
         # Bus nodes
-        bus_groups = bus_df.groupby("scenario")
-
-        bus_df = bus_groups.get_group(scenario)
-        # assert that the buses are in increasing order
-        assert (bus_df["bus"].values == torch.arange(len(bus_df))).all(), (
-            "Buses are not in increasing order"
-        )
         # todo: we should remove this assert and store the bus idx in the tensors
         # right now we need the increasing order for e.g. the predict step that uses torch.arange(n_nodes) to index the buses.
         data["bus"].x = torch.tensor(bus_df[bus_features].values, dtype=torch.float)

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -379,6 +379,8 @@ class HeteroGridDatasetDisk(Dataset):
         data = HeteroData()
 
         # Bus nodes
+        bus_groups = bus_df.groupby("scenario")
+
         bus_df = bus_groups.get_group(scenario)
         # assert that the buses are in increasing order
         assert (bus_df["bus"].values == torch.arange(len(bus_df))).all(), (

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -8,7 +8,7 @@ import pandas as pd
 from tqdm import tqdm
 from typing import Optional, Callable
 from torch_geometric.data import HeteroData
-from gridfm_graphkit.datasets.globals import VA_H, PG_H
+from gridfm_graphkit.datasets.globals import VA_H, PG_H, MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV, ANG_MIN, ANG_MAX, RATE_A
 
 
 class HeteroGridDatasetDisk(Dataset):
@@ -367,8 +367,16 @@ class HeteroGridDatasetDisk(Dataset):
 
         data = HeteroData()
 
-        # Bus nodes
-        data["bus"].x = torch.tensor(bus_df[bus_features].values, dtype=torch.float)
+            # Bus nodes
+            bus_df = bus_groups.get_group(scenario)
+            # assert that the buses are in increasing order
+            assert (bus_df["bus"].values == torch.arange(len(bus_df))).all(), (
+                "Buses are not in increasing order"
+            )
+            # todo: we should remove this assert and store the bus idx in the tensors
+            # right now we need the increasing order for e.g. the predict step that uses torch.arange(n_nodes) to index the buses.
+            data["bus"].x = torch.tensor(bus_df[bus_features].values, dtype=torch.float)
+            data["bus"].static = data["bus"].x[:, [MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV]].clone()
 
         # Generator nodes
         gen_df = gen_df.reset_index()
@@ -409,9 +417,10 @@ class HeteroGridDatasetDisk(Dataset):
         )
         edge_y = torch.cat([forward_targets, reverse_targets], dim=0)
 
-        data["bus", "connects", "bus"].edge_index = edge_index
-        data["bus", "connects", "bus"].edge_attr = edge_attr
-        data["bus", "connects", "bus"].y = edge_y
+            data["bus", "connects", "bus"].edge_index = edge_index
+            data["bus", "connects", "bus"].edge_attr = edge_attr
+            data["bus", "connects", "bus"].static = edge_attr[:, [ANG_MIN, ANG_MAX, RATE_A]].clone()
+            data["bus", "connects", "bus"].y = edge_y
 
         # Gen-Bus and Bus-Gen edges
         data["gen", "connected_to", "bus"].edge_index = torch.tensor(

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -6,7 +6,7 @@ import torch
 from torch_geometric.data import Dataset
 import pandas as pd
 from tqdm import tqdm
-from typing import Any, Optional, Callable
+from typing import Optional, Callable
 from torch_geometric.data import HeteroData
 from gridfm_graphkit.datasets.globals import (
     VA_H,
@@ -379,6 +379,9 @@ class HeteroGridDatasetDisk(Dataset):
         data = HeteroData()
 
         # Bus nodes
+        bus_groups = bus_df.groupby("scenario")
+
+        bus_df = bus_groups.get_group(scenario)
         # assert that the buses are in increasing order
         assert (bus_df["bus"].values == torch.arange(len(bus_df))).all(), (
             "Buses are not in increasing order"

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -6,7 +6,7 @@ import torch
 from torch_geometric.data import Dataset
 import pandas as pd
 from tqdm import tqdm
-from typing import Optional, Callable
+from typing import Any, Optional, Callable
 from torch_geometric.data import HeteroData
 from gridfm_graphkit.datasets.globals import (
     VA_H,
@@ -379,9 +379,6 @@ class HeteroGridDatasetDisk(Dataset):
         data = HeteroData()
 
         # Bus nodes
-        bus_groups = bus_df.groupby("scenario")
-
-        bus_df = bus_groups.get_group(scenario)
         # assert that the buses are in increasing order
         assert (bus_df["bus"].values == torch.arange(len(bus_df))).all(), (
             "Buses are not in increasing order"

--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -8,7 +8,18 @@ import pandas as pd
 from tqdm import tqdm
 from typing import Optional, Callable
 from torch_geometric.data import HeteroData
-from gridfm_graphkit.datasets.globals import VA_H, PG_H, MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV, ANG_MIN, ANG_MAX, RATE_A
+from gridfm_graphkit.datasets.globals import (
+    VA_H,
+    PG_H,
+    MIN_VM_H,
+    MAX_VM_H,
+    MIN_QG_H,
+    MAX_QG_H,
+    VN_KV,
+    ANG_MIN,
+    ANG_MAX,
+    RATE_A,
+)
 
 
 class HeteroGridDatasetDisk(Dataset):
@@ -376,7 +387,11 @@ class HeteroGridDatasetDisk(Dataset):
             # todo: we should remove this assert and store the bus idx in the tensors
             # right now we need the increasing order for e.g. the predict step that uses torch.arange(n_nodes) to index the buses.
             data["bus"].x = torch.tensor(bus_df[bus_features].values, dtype=torch.float)
-            data["bus"].static = data["bus"].x[:, [MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV]].clone()
+            data["bus"].static = (
+                data["bus"]
+                .x[:, [MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV]]
+                .clone()
+            )
 
         # Generator nodes
         gen_df = gen_df.reset_index()
@@ -419,7 +434,10 @@ class HeteroGridDatasetDisk(Dataset):
 
             data["bus", "connects", "bus"].edge_index = edge_index
             data["bus", "connects", "bus"].edge_attr = edge_attr
-            data["bus", "connects", "bus"].static = edge_attr[:, [ANG_MIN, ANG_MAX, RATE_A]].clone()
+            data["bus", "connects", "bus"].static = edge_attr[
+                :,
+                [ANG_MIN, ANG_MAX, RATE_A],
+            ].clone()
             data["bus", "connects", "bus"].y = edge_y
 
         # Gen-Bus and Bus-Gen edges

--- a/gridfm_graphkit/datasets/transforms.py
+++ b/gridfm_graphkit/datasets/transforms.py
@@ -72,6 +72,8 @@ class RemoveInactiveBranches(BaseTransform):
         data[et].edge_attr = data[et].edge_attr[active_mask]
         data[et].edge_attr = data[et].edge_attr[:, :B_ON]
         data[et].y = data[et].y[active_mask]
+        if hasattr(data[et], "static"):
+            data[et].static = data[et].static[active_mask]
 
         return data
 

--- a/gridfm_graphkit/tasks/pf_task.py
+++ b/gridfm_graphkit/tasks/pf_task.py
@@ -18,6 +18,7 @@ from gridfm_graphkit.datasets.globals import (
     QG_OUT,
 )
 
+from gridfm_graphkit.datasets.masking import RemovePFMask
 from gridfm_graphkit.tasks.reconstruction_tasks import ReconstructionTask
 from gridfm_graphkit.io.registries import TASK_REGISTRY
 from gridfm_graphkit.tasks.utils import (
@@ -127,6 +128,7 @@ class PowerFlowTask(ReconstructionTask):
 
         self.data_normalizers[dataloader_idx].inverse_transform(batch)
         self.data_normalizers[dataloader_idx].inverse_output(output, batch)
+        RemovePFMask()(batch)
 
         branch_flow_layer = ComputeBranchFlow()
         node_injection_layer = ComputeNodeInjection()
@@ -436,6 +438,7 @@ class PowerFlowTask(ReconstructionTask):
             output,
             batch,
         )  # inverse transform the predicted output back to the original scale
+        RemovePFMask()(batch)
 
         branch_flow_layer = ComputeBranchFlow()  # layer to compute the branch flows
         node_injection_layer = (

--- a/tests/test_remove_pf_mask.py
+++ b/tests/test_remove_pf_mask.py
@@ -1,0 +1,141 @@
+"""Tests that the .static attribute is correctly saved at dataset build time
+and that RemovePFMask restores the zeroed limit columns after inverse_transform.
+"""
+
+import copy
+
+import pytest
+import torch
+import yaml
+from torch_geometric.data import HeteroData
+
+from gridfm_graphkit.datasets.globals import (
+    ANG_MAX,
+    ANG_MIN,
+    MAX_QG_H,
+    MAX_VM_H,
+    MIN_QG_H,
+    MIN_VM_H,
+    RATE_A,
+    VN_KV,
+)
+from gridfm_graphkit.datasets.masking import AddPFHeteroMask, RemovePFMask
+from gridfm_graphkit.datasets.normalizers import HeteroDataMVANormalizer
+from gridfm_graphkit.datasets.transforms import ApplyMasking
+from gridfm_graphkit.io.param_handler import NestedNamespace
+
+_DATA_PATH = "tests/data/case14_ieee/processed/data_index_0.pt"
+_STATS_PATH = "tests/data/case14_ieee/processed/data_stats_HeteroDataMVANormalizer.pt"
+_CONFIG_PATH = "tests/config/datamodule_test_base_config.yaml"
+
+BUS_LIMIT_COLS = [MIN_VM_H, MAX_VM_H, MIN_QG_H, MAX_QG_H, VN_KV]
+BRANCH_LIMIT_COLS = [ANG_MIN, ANG_MAX, RATE_A]
+
+
+@pytest.fixture(scope="module")
+def raw_data():
+    """Load a single processed scenario, un-normalised."""
+    data_dict = torch.load(_DATA_PATH, weights_only=True)
+    return HeteroData.from_dict(data_dict)
+
+
+@pytest.fixture(scope="module")
+def args():
+    with open(_CONFIG_PATH) as f:
+        cfg = yaml.safe_load(f)
+    return NestedNamespace(**cfg)
+
+
+@pytest.fixture(scope="module")
+def normalizer(args):
+    stats = torch.load(_STATS_PATH, weights_only=True)
+    n = HeteroDataMVANormalizer(args)
+    n.fit_from_dict(stats)
+    return n
+
+
+def test_static_attribute_saved_at_build_time(raw_data):
+    """Dataset build saves .static with the raw limit values before masking."""
+    assert hasattr(raw_data["bus"], "static"), (
+        "data['bus'].static not found — was the dataset reprocessed after the fix?"
+    )
+    assert hasattr(raw_data[("bus", "connects", "bus")], "static"), (
+        "data[('bus','connects','bus')].static not found — was the dataset reprocessed?"
+    )
+
+    bus_static = raw_data["bus"].static
+    branch_static = raw_data[("bus", "connects", "bus")].static
+
+    # static must match the corresponding columns of x / edge_attr exactly
+    assert torch.equal(
+        bus_static,
+        raw_data["bus"].x[:, BUS_LIMIT_COLS],
+    ), "bus.static does not match bus.x limit columns"
+    assert torch.equal(
+        branch_static,
+        raw_data[("bus", "connects", "bus")].edge_attr[:, BRANCH_LIMIT_COLS],
+    ), "edge static does not match edge_attr limit columns"
+
+    # sanity: limits should not all be zero in real data
+    assert bus_static.abs().sum() > 0, (
+        "bus.static is all zeros — raw data may be missing limit values"
+    )
+    assert branch_static.abs().sum() > 0, (
+        "branch.static is all zeros — raw data may be missing limit values"
+    )
+
+
+def test_remove_pf_mask_restores_limits(raw_data, args, normalizer):
+    """RemovePFMask restores correct limit values after the full transform pipeline."""
+    data = copy.deepcopy(raw_data)
+
+    # Replicate exactly what happens at inference time.
+    # Call .forward() directly (not __call__) to avoid BaseTransform's
+    # internal copy.copy() which would discard mask_dict between steps.
+    # 1. normalise
+    normalizer.transform(data)
+    # 2. add PF mask (marks limit cols)
+    AddPFHeteroMask().forward(data)
+    # 3. apply masking (zeros limit cols)
+    ApplyMasking(args).forward(data)
+
+    # At this point limits should be zero
+    assert data.x_dict["bus"][:, BUS_LIMIT_COLS].abs().sum() == 0, (
+        "Expected bus limit columns to be zero after ApplyMasking"
+    )
+    assert (
+        data.edge_attr_dict[("bus", "connects", "bus")][:, BRANCH_LIMIT_COLS]
+        .abs()
+        .sum()
+        == 0
+    ), "Expected branch limit columns to be zero after ApplyMasking"
+
+    # 4. inverse transform (zeros × baseMVA = still zeros — the original bug)
+    normalizer.inverse_transform(data)
+
+    assert data.x_dict["bus"][:, BUS_LIMIT_COLS].abs().sum() == 0, (
+        "Sanity: bus limits should still be zero before RemovePFMask"
+    )
+
+    # 5. RemovePFMask restores them
+    RemovePFMask()(data)
+
+    restored_bus = data.x_dict["bus"][:, BUS_LIMIT_COLS]
+    restored_branch = data.edge_attr_dict[("bus", "connects", "bus")][:, BRANCH_LIMIT_COLS]
+
+    assert restored_bus.abs().sum() > 0, (
+        "Bus limit columns are still zero after RemovePFMask"
+    )
+    assert restored_branch.abs().sum() > 0, (
+        "Branch limit columns are still zero after RemovePFMask"
+    )
+
+    # Values must match the original raw limits stored in .static
+    assert torch.allclose(restored_bus, raw_data["bus"].static, atol=1e-5), (
+        "Restored bus limits do not match the original raw values in .static"
+    )
+    assert torch.allclose(
+        restored_branch,
+        raw_data[("bus", "connects", "bus")].static,
+        atol=1e-5,
+    ), "Restored branch limits do not match the original raw values in .static"

--- a/tests/test_remove_pf_mask.py
+++ b/tests/test_remove_pf_mask.py
@@ -121,7 +121,10 @@ def test_remove_pf_mask_restores_limits(raw_data, args, normalizer):
     RemovePFMask()(data)
 
     restored_bus = data.x_dict["bus"][:, BUS_LIMIT_COLS]
-    restored_branch = data.edge_attr_dict[("bus", "connects", "bus")][:, BRANCH_LIMIT_COLS]
+    restored_branch = data.edge_attr_dict[("bus", "connects", "bus")][
+        :,
+        BRANCH_LIMIT_COLS,
+    ]
 
     assert restored_bus.abs().sum() > 0, (
         "Bus limit columns are still zero after RemovePFMask"


### PR DESCRIPTION
addresses issue: https://github.com/gridfm/gridfm-graphkit/issues/104

**Summary**
In the PowerFlow task, `AddPFHeteroMask` zeros out static limit columns so the model cannot see them during the forward pass. These columns remained zero after `inverse_transform`/`inverse_output`, causing zero values to be written into the limit fields of the `predict_step` output.


**Changes**
`powergrid_hetero_dataset.py` — at dataset build time, saves raw physical limit values into a separate .static attribute on `data["bus"]` and `data[("bus","connects","bus")]` before any masking or normalisation runs. Requires dataset reprocessing for tests (delete `processed/`).

`masking.py` — adds `RemovePFMask`, a transform that copies .static back into the masked limit columns of `batch.x_dict["bus"]` and `batch.edge_attr_dict[("bus","connects","bus")]`.

`pf_task.py` — calls `RemovePFMask()(batch)` in both `test_step` and `predict_step` immediately after `inverse_output`, so correct limit values are present when the output is assembled.

IMPORTATNT: No data leakage — `.static` is written to a separate attribute that is never passed to the model. The model still sees zeros in the limit columns throughout the forward pass.