### PR TITLE
docs(contributing): add a Scope section routing app-specific work to a companion apps repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 Thank you for your interest in contributing to GridFM. This document explains our contribution process and procedures:
 
+* [Scope: What Belongs in This Repository](#Scope-What-Belongs-in-This-Repository)
 * [How to Contribute a Bug Fix or Change](#How-to-Contribute-a-Bug-Fix-or-Change)
 * [Running the Integration Tests](#Running-the-Integration-Tests)
 * [Development Workflow](#Development-Workflow)
@@ -10,6 +11,28 @@ Thank you for your interest in contributing to GridFM. This document explains ou
 For a description of the roles and responsibilities of the various members of the GridFM community, see the [governance policies], and for further details, see the project's [Technical Charter]. Briefly, Contributors are anyone who submits content to the project, Committers review and approve such submissions, and the Technical Steering Committee provides general project oversight.
 
 If you just need help or have a question, refer to [SUPPORT.md](SUPPORT.md).
+
+## Scope: What Belongs in This Repository
+
+`gridfm-graphkit` is a **library** for training, finetuning, and interacting with a
+foundation model for the electric power grid. Contributions that extend or improve
+this core belong here — for example:
+
+* Model architectures, layers, and loss functions.
+* Training, finetuning, and evaluation logic.
+* Data loading, transforms, and shared utilities.
+* Bug fixes, performance improvements, tests, and documentation for the above.
+
+**Application-specific contributions belong in a companion GridFM applications
+repository, not here.** If your contribution is an end-to-end application, a
+deployment, or a pipeline/notebook/experiment tied to one specific use case or
+study, please contribute it to the relevant GridFM applications repository instead
+of adding it to the core library. Keeping application-specific code out of the core
+keeps this library focused, broadly reusable, and free of use-case-specific
+dependencies.
+
+If you are unsure whether a contribution is "core" or "application-specific", open
+an issue to discuss it before starting work.
 
 ## How to Contribute a Bug Fix or Change
 


### PR DESCRIPTION
## What

Adds a **"Scope: What Belongs in This Repository"** section to `CONTRIBUTING.md` (and a matching table-of-contents entry).

The section clarifies:
- `gridfm-graphkit` is the **core library** (model architectures/losses, training/finetuning/evaluation, data loading & shared utilities, plus fixes/tests/docs for those).
- **Application-specific contributions** — end-to-end apps, deployments, or pipelines/notebooks/experiments tied to one use case or study — should go to the relevant **companion GridFM applications repository**, not the core library.
- If unsure whether something is "core" vs "application-specific", open an issue to discuss first.

## Why

`CONTRIBUTING.md` currently documents *how* to contribute but never *what kind* of contribution belongs here. This leaves the core/app boundary implicit. Making it explicit keeps the core library focused, broadly reusable, and free of use-case-specific dependencies.

## Notes

- Docs-only change; no code, so no new tests required.
- Wording intentionally does **not** hard-link a specific apps repository name, so it stays correct regardless of the exact repo naming. A concrete link can be added once the target repo is finalized.
- Commit is DCO signed-off per `CONTRIBUTING.md`.