### PR TITLE
Pin juliapkg<0.1.24 to fix repo-wide pytest collection failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,11 @@ dependencies = [
     "urllib3>=2.6.0",
     "gdown>=6.0.0",
     "gridfm-datakit==1.0.5",
+    # juliapkg >= 0.1.24 renamed run_julia -> run_script, which breaks the
+    # released gridfm-datakit 1.0.5 (it imports run_julia at module load,
+    # failing collection of all pytests). Pin until datakit 1.0.6 (fix in
+    # gridfm/gridfm-datakit@c1f3cb5) is released, then remove this line.
+    "juliapkg<0.1.24",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

`pytests` has been failing on **every** open PR — not due to any PR's code, but an upstream dependency break:

- `juliapkg` **0.1.24** renamed `run_julia` → `run_script`.
- The released **`gridfm-datakit==1.0.5`** (our pinned dep) imports `run_julia` at module load in `gridfm_datakit/network.py`.
- Fresh installs pull the latest `juliapkg` (0.1.26), so importing `gridfm_datakit.network` raises `ImportError: cannot import name 'run_julia'`, which fails **collection of all tests** (`test_node_rank.py`, `test_pipeline.py`, `test_predict_embeddings.py`).

## Fix

Pin `juliapkg<0.1.24` (resolves to 0.1.23), which still exposes `run_julia`, restoring compatibility with the released datakit 1.0.5.

## Verification

In a clean venv with `gridfm-datakit==1.0.5 juliapkg<0.1.24`:
- `juliapkg` resolves to `0.1.23`
- `from juliapkg.deps import run_julia` ✅
- `import gridfm_datakit.network` ✅ (the module that failed CI collection)

## Temporary

datakit already handles the rename in `gridfm/gridfm-datakit@c1f3cb5` but it's unreleased. Once **gridfm-datakit 1.0.6** ships, bump the datakit pin and remove this juliapkg pin. Tracked as the follow-up to #103's CI-unblock effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)