### PR TITLE
Add linear warmup for physics loss weight

### DIFF
--- a/docs/quick_start/yaml_config.md
+++ b/docs/quick_start/yaml_config.md
@@ -194,6 +194,28 @@ Common `loss_args` patterns:
 - `LossPerDim`: `{dim: VM|VA|P_in|Q_in, loss_str: MAE|MSE}`
 - `MaskedGenMSE`, `MaskedBusMSE`, `QgViolationPenalty`, `MaskedMSE`, `MSE`: `{}`
 
+### Physics loss warmup
+
+- `physics_warmup_epochs`: number of epochs over which the weight of every
+  `LayeredWeightedPhysics` term ramps linearly up to its value in `loss_weights`,
+  instead of being applied at full strength from the first epoch. The weight at
+  epoch `e` (0-indexed) is `loss_weight * min(1, (e + 1) / physics_warmup_epochs)`,
+  so it reaches its target on the last warmup epoch. Defaults to `0`, which
+  disables the ramp and keeps all weights constant.
+
+Ramping the physics term in is useful when it dominates the gradient early in
+training, before the supervised reconstruction terms have settled:
+
+```yaml
+training:
+  losses: [LayeredWeightedPhysics, MaskedBusMSE]
+  loss_weights: [0.2, 0.8]
+  loss_args:
+  - base_weight: 0.5
+  - {}
+  physics_warmup_epochs: 20
+```
+
 ---
 
 ## `optimizer` section

--- a/examples/config/HGNS_PF_datakit_case118.yaml
+++ b/examples/config/HGNS_PF_datakit_case118.yaml
@@ -53,6 +53,7 @@ training:
   loss_args:
   - base_weight: 0.5
   - {}
+  physics_warmup_epochs: 0 # set >0 to ramp LayeredWeightedPhysics in linearly
   accelerator: auto
   devices: auto
   strategy: auto

--- a/gridfm_graphkit/io/param_handler.py
+++ b/gridfm_graphkit/io/param_handler.py
@@ -103,7 +103,19 @@ def get_loss_function(args):
         except KeyError:
             raise ValueError(f"Unknown loss: {loss_name}")
 
-    return MixedLoss(loss_functions=loss_functions, weights=args.training.loss_weights)
+    warmup_epochs = getattr(args.training, "physics_warmup_epochs", 0)
+    warmup_indices = [
+        i
+        for i, loss_name in enumerate(args.training.losses)
+        if loss_name == "LayeredWeightedPhysics"
+    ]
+
+    return MixedLoss(
+        loss_functions=loss_functions,
+        weights=args.training.loss_weights,
+        warmup_indices=warmup_indices,
+        warmup_epochs=warmup_epochs,
+    )
 
 
 def load_model(args) -> torch.nn.Module:

--- a/gridfm_graphkit/tasks/reconstruction_tasks.py
+++ b/gridfm_graphkit/tasks/reconstruction_tasks.py
@@ -42,6 +42,9 @@ class ReconstructionTask(BaseTask):
     def forward(self, batch):
         return self.model(batch)
 
+    def on_train_epoch_start(self):
+        self.loss_fn.set_epoch(self.current_epoch)
+
     def shared_step(self, batch):
         output = self.forward(batch)
 

--- a/gridfm_graphkit/training/loss.py
+++ b/gridfm_graphkit/training/loss.py
@@ -274,9 +274,16 @@ class MixedLoss(BaseLoss):
     Args:
         loss_functions (list[nn.Module]): List of loss functions.
         weights (list[float]): Corresponding weights for each loss function.
+        warmup_indices (list[int], optional): Indices into `loss_functions` whose
+            weight should ramp linearly from 0 up to its target value over
+            `warmup_epochs` epochs, instead of being constant. Used to delay
+            physics-loss terms until the model has learned a stable supervised
+            baseline. Defaults to no warmup (all weights constant at their target).
+        warmup_epochs (int, optional): Number of epochs over which `warmup_indices`
+            weights ramp up. 0 disables warmup (default, unchanged behavior).
     """
 
-    def __init__(self, loss_functions, weights):
+    def __init__(self, loss_functions, weights, warmup_indices=None, warmup_epochs=0):
         super(MixedLoss, self).__init__()
 
         if len(loss_functions) != len(weights):
@@ -285,7 +292,18 @@ class MixedLoss(BaseLoss):
             )
 
         self.loss_functions = nn.ModuleList(loss_functions)
-        self.weights = weights
+        self.target_weights = list(weights)
+        self.weights = list(weights)
+        self.warmup_indices = warmup_indices or []
+        self.warmup_epochs = warmup_epochs
+
+    def set_epoch(self, epoch):
+        """Update ramped weights for the given (0-indexed) training epoch."""
+        if not self.warmup_indices or self.warmup_epochs <= 0:
+            return
+        alpha = min(1.0, (epoch + 1) / self.warmup_epochs)
+        for i in self.warmup_indices:
+            self.weights[i] = self.target_weights[i] * alpha
 
     def forward(
         self,

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,7 +1,8 @@
 import pytest
 import torch
 from gridfm_graphkit.datasets.hetero_powergrid_datamodule import LitGridHeteroDataModule
-from gridfm_graphkit.io.param_handler import NestedNamespace
+from gridfm_graphkit.io.param_handler import NestedNamespace, get_loss_function
+from gridfm_graphkit.training.loss import MixedLoss
 from gridfm_graphkit.datasets.globals import VM_H, VA_H, QG_H
 from torch_scatter import scatter_add
 from gridfm_graphkit.models.utils import (
@@ -75,3 +76,92 @@ def test_pbe_loss_zero_with_real_data(small_grid_data_module):
     assert torch.max(torch.abs(residual_Q)) < 1e-4, (
         f"Reactive Residuals not zero! {torch.max(torch.abs(residual_Q))}"
     )
+
+
+class ConstantLoss(torch.nn.Module):
+    """Loss stub returning a fixed value, to check how MixedLoss weights terms."""
+
+    def __init__(self, value):
+        super().__init__()
+        self.value = value
+
+    def forward(self, pred, target, *args, **kwargs):
+        return {"loss": torch.tensor(self.value)}
+
+
+def test_mixed_loss_weights_constant_without_warmup():
+    loss_fn = MixedLoss(
+        loss_functions=[ConstantLoss(1.0), ConstantLoss(2.0)],
+        weights=[0.1, 0.9],
+    )
+
+    for epoch in range(5):
+        loss_fn.set_epoch(epoch)
+        assert loss_fn.weights == [0.1, 0.9]
+
+
+def test_mixed_loss_warmup_ramps_linearly_then_clamps():
+    loss_fn = MixedLoss(
+        loss_functions=[ConstantLoss(1.0), ConstantLoss(2.0)],
+        weights=[1.0, 0.5],
+        warmup_indices=[0],
+        warmup_epochs=4,
+    )
+
+    # alpha = (epoch + 1) / warmup_epochs, so the ramp starts at one step of the
+    # ramp rather than at 0 and reaches its target on the last warmup epoch.
+    expected = [0.25, 0.5, 0.75, 1.0]
+    for epoch, target in enumerate(expected):
+        loss_fn.set_epoch(epoch)
+        assert loss_fn.weights[0] == pytest.approx(target)
+        # weights outside warmup_indices are never touched
+        assert loss_fn.weights[1] == pytest.approx(0.5)
+
+    # past the warmup window the weight stays at its target value
+    for epoch in (4, 10, 200):
+        loss_fn.set_epoch(epoch)
+        assert loss_fn.weights[0] == pytest.approx(1.0)
+
+
+def test_mixed_loss_warmup_scales_total_loss():
+    loss_fn = MixedLoss(
+        loss_functions=[ConstantLoss(4.0), ConstantLoss(1.0)],
+        weights=[1.0, 2.0],
+        warmup_indices=[0],
+        warmup_epochs=2,
+    )
+
+    loss_fn.set_epoch(0)  # alpha = 0.5 -> 0.5 * 4.0 + 2.0 * 1.0
+    assert loss_fn(None, None)["loss"].item() == pytest.approx(4.0)
+
+    loss_fn.set_epoch(1)  # alpha = 1.0 -> 1.0 * 4.0 + 2.0 * 1.0
+    assert loss_fn(None, None)["loss"].item() == pytest.approx(6.0)
+
+
+@pytest.fixture
+def loss_config():
+    import yaml
+
+    with open("tests/config/datamodule_test_base_config.yaml") as f:
+        return yaml.safe_load(f)
+
+
+def test_get_loss_function_ramps_physics_terms(loss_config):
+    # config declares losses [LayeredWeightedPhysics, MaskedBusMSE]
+    loss_config["training"]["physics_warmup_epochs"] = 10
+    loss_fn = get_loss_function(NestedNamespace(**loss_config))
+
+    assert loss_fn.warmup_indices == [0]
+    assert loss_fn.warmup_epochs == 10
+
+    loss_fn.set_epoch(4)
+    assert loss_fn.weights[0] == pytest.approx(0.1 * 0.5)
+    assert loss_fn.weights[1] == pytest.approx(0.9)
+
+
+def test_get_loss_function_without_warmup_key_is_unchanged(loss_config):
+    loss_fn = get_loss_function(NestedNamespace(**loss_config))
+
+    assert loss_fn.warmup_epochs == 0
+    loss_fn.set_epoch(3)
+    assert loss_fn.weights == loss_fn.target_weights


### PR DESCRIPTION
## What

Adds an opt-in linear warmup for physics loss weights in `MixedLoss`.

When a `LayeredWeightedPhysics` term is combined with supervised reconstruction
terms, applying it at full strength from the first step can dominate the gradient
before the reconstruction terms have settled. This PR lets that weight ramp in
linearly over the first `training.physics_warmup_epochs` epochs instead.

## How

- `MixedLoss` takes two new optional arguments, `warmup_indices` and
  `warmup_epochs`, and keeps the configured weights as `target_weights`.
- `MixedLoss.set_epoch(epoch)` recomputes the ramped weights as
  `target * min(1, (epoch + 1) / warmup_epochs)`, so a weight reaches its target
  on the last warmup epoch and stays there afterwards.
- `ReconstructionTask.on_train_epoch_start` calls `set_epoch(self.current_epoch)`.
- `get_loss_function` reads `training.physics_warmup_epochs` (default `0`) and
  marks every `LayeredWeightedPhysics` entry in `training.losses` for ramping.

## Backwards compatibility

Fully opt-in. With the default `physics_warmup_epochs: 0` — i.e. every existing
config — `set_epoch` returns immediately and the weights stay constant at their
configured values, so training behavior is unchanged.

## Testing

`tests/test_losses.py` gains five tests covering: constant weights without warmup,
the linear ramp and its clamp past the warmup window, non-ramped weights staying
untouched, the effect on the total loss value, and the config plumbing through
`get_loss_function` (both with and without the new key).

- `pytest tests/` — 52 passed
- `pre-commit run --all-files` — all hooks passed

## Docs

`docs/quick_start/yaml_config.md` documents `physics_warmup_epochs` under the
`training` section, with the ramp formula and an example.
