### PR TITLE
Bump gridfm-datakit to 1.1.0rc1 and drop juliapkg pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,7 @@ dependencies = [
     "seaborn",
     "urllib3>=2.6.0",
     "gdown>=6.0.0",
-    "gridfm-datakit==1.0.5",
-    # juliapkg >= 0.1.24 renamed run_julia -> run_script, which breaks the
-    # released gridfm-datakit 1.0.5 (it imports run_julia at module load,
-    # failing collection of all pytests). Pin until datakit 1.0.6 (fix in
-    # gridfm/gridfm-datakit@c1f3cb5) is released, then remove this line.
-    "juliapkg<0.1.24",
+    "gridfm-datakit==1.1.0rc1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What

- Bump `gridfm-datakit` `1.0.5` -> `1.1.0rc1`.
- Remove the temporary `juliapkg<0.1.24` pin (and its explanatory comment).

## Why

datakit `1.1.0rc1` imports `run_script` instead of the removed `run_julia`, so it works with `juliapkg >= 0.1.24`. The pin was a stopgap added while datakit `1.0.5` (which imports `run_julia` at module load) was the latest release; with it gone, pytest collection was failing repo-wide. Bumping datakit and dropping the pin fixes CI on `main`; open PRs inherit the fix on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)