### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ namespaces = false
 [project]
 name = "gridfm-graphkit"
 description = "Grid Foundation Model"
-version = "0.8.1"
+version = "0.9.0"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1113,7 +1113,7 @@ wheels = [
 
 [[package]]
 name = "gridfm-graphkit"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "gdown" },


### PR DESCRIPTION
Version bump `0.8.1` -> `0.9.0` for the 0.9.0 release.

**Context**
- datakit dependency is pinned to `==1.1.0` (final) as of #113.
- Integration tests validated on Vela (single H100) with current main (graphkit 0.8.1 code / datakit 1.1.0 / torch 2.12.1) against the prior calibrated baseline (graphkit 0.8.0 / datakit 1.0.5rc1): **all PF + 10 OPF metrics within bounds, 2 passed**.

After this merges, tagging `v0.9.0` on main triggers `release.yaml` -> build + publish to PyPI.

Leaving for human review/approval - not admin-merging.