### PR TITLE
fix(datasets): copy transposed edge arrays to avoid negative strides

### DIFF
--- a/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
+++ b/gridfm_graphkit/datasets/powergrid_hetero_dataset.py
@@ -379,8 +379,11 @@ class HeteroGridDatasetDisk(Dataset):
         data["gen"].y = data["gen"].x[:, : (PG_H + 1)].clone()
 
         # Bus-Bus edges
+        # `.copy()` forces a contiguous array: selecting columns in reverse
+        # order and transposing can yield a negatively-strided view, which
+        # torch.tensor / torch.from_numpy does not support.
         forward_edges = torch.tensor(
-            branch_df[["from_bus", "to_bus"]].values.T,
+            branch_df[["from_bus", "to_bus"]].values.T.copy(),
             dtype=torch.long,
         )
         forward_edge_attr = torch.tensor(
@@ -388,7 +391,7 @@ class HeteroGridDatasetDisk(Dataset):
             dtype=torch.float,
         )
         reverse_edges = torch.tensor(
-            branch_df[["to_bus", "from_bus"]].values.T,
+            branch_df[["to_bus", "from_bus"]].values.T.copy(),
             dtype=torch.long,
         )
         reverse_edge_attr = torch.tensor(
@@ -415,11 +418,11 @@ class HeteroGridDatasetDisk(Dataset):
 
         # Gen-Bus and Bus-Gen edges
         data["gen", "connected_to", "bus"].edge_index = torch.tensor(
-            gen_df[["gen_index", "bus"]].values.T,
+            gen_df[["gen_index", "bus"]].values.T.copy(),
             dtype=torch.long,
         )
         data["bus", "connected_to", "gen"].edge_index = torch.tensor(
-            gen_df[["bus", "gen_index"]].values.T,
+            gen_df[["bus", "gen_index"]].values.T.copy(),
             dtype=torch.long,
         )
 


### PR DESCRIPTION
## What

Adds `.copy()` to the four transposed `.values.T` conversions in the streaming scenario builder (`powergrid_hetero_dataset.py`), forcing a contiguous array before `torch.tensor(...)`.

## Why

The whole pytest suite currently errors at collection (121 errors), all with:

```
ValueError: At least one stride in the given numpy array is negative, and
tensors with negative strides are not currently supported.
```

Traceback lands at `powergrid_hetero_dataset.py:390`, building `reverse_edges` from `branch_df[["to_bus", "from_bus"]].values.T`. A **newer pandas** (CI installs deps unpinned — `pip install -e ".[test]"`, the `uv.lock` is not used) returns a **negatively-strided** array for a reverse-ordered column selection followed by `.T`, which `torch.from_numpy`/`torch.tensor` rejects.

The forward selection one line up (`["from_bus", "to_bus"]`, line 382) does **not** trip it — confirming the reverse-order selection as the trigger, not the transpose alone. Nothing in the repo changed; the code and the pinned lockfile are identical to the last green run — only the freshly-resolved pandas moved.

## Fix

`.copy()` yields a C-contiguous array with positive strides at the `torch.tensor` boundary, independent of numpy/pandas version. Applied to all four transposed conversions (both edge directions for bus–bus and gen–bus) for symmetry and defensiveness.

## Validation

Could not reproduce locally (workstation pandas 2.3.3 / numpy 2.4.2 still return positive strides); **CI is the validator** — this PR's pytests should go green where `main`'s freshly-resolved run does not.

## Notes

- Supersedes #116 (which capped numpy — a wrong lead: the cap resolved numpy 2.5.2 and still failed, proving numpy version wasn't the variable). #116 will be closed.
- Follow-up worth considering: have CI install from the committed `uv.lock` for reproducibility, so a fresh upstream release can't silently break every PR again.