### PR TITLE
docs: add citations to docs homepage and align naming

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,39 @@
-# gridfm-graphkit
-
 <p align="center">
-  <img src="figs/KIT.png" alt="GridFM logo" style="width: 30%; height: auto;"/>
+  <img src="figs/KIT.png" alt="GridFM logo" style="width: 40%; height: auto;"/>
   <br/>
 </p>
 
----
+<p align="center" style="font-size: 25px;">
+    <b>gridfm-graphkit</b>
+</p>
+
+
+# GridFM graphkit
 
 This library is brought to you by the GridFM team to train, finetune and interact with a foundation model for the electric power grid.
 
----
+## Citation
 
+If you use `gridfm-graphkit` in your research, please cite:
 
+```bibtex
+@article{puech2026gencounifiedneural,
+  title={GENCO - A Unified Neural Solver Embedded in a Development Framework for Steady-State Grid Analysis},
+  author={Alban Puech and Matteo Mazzonelli and Tamara R. Govindasamy and Mangaliso Mngomezulu and Héctor Maeso-García and Thomas Tolhurst and Javad Bayazi and Ali Moeini and Naomi Simumba and Celia Cintas and David Nelischer and Romeo Kienzler and Jonas Weiss and Anna Varbella and Florian Dörfler and Gabriela Hug and Martin Mevissen and Juan Bernabé-Moreno and François Mirallès and Hendrik F. Hamann and Etienne Vos and Thomas Brunschwiler},
+  journal={arXiv preprint arXiv:2608.09921},
+  year={2026},
+  url={https://arxiv.org/abs/2608.09921}
+}
+```
 
+If you also used `gridfm-datakit`, please also cite:
 
-## Citation: TBD
+```bibtex
+@article{puech2025gridfmdatakitv1pythonlibraryscalable,
+  title={gridfm-datakit-v1: A Python Library for Scalable and Realistic Power Flow and Optimal Power Flow Data Generation},
+  author={Alban Puech and Matteo Mazzonelli and Celia Cintas and Tamara R. Govindasamy and Mangaliso Mngomezulu and Jonas Weiss and Matteo Baù and Anna Varbella and François Mirallès and Kibaek Kim and Le Xie and Hendrik F. Hamann and Etienne Vos and Thomas Brunschwiler},
+  journal={arXiv preprint arXiv:2512.14658},
+  year={2025},
+  url={https://arxiv.org/abs/2512.14658}
+}
+```


### PR DESCRIPTION
## Summary
- Replace the `Citation: TBD` placeholder on the docs homepage with the BibTeX blocks from `README.md`
- Align `docs/index.md` layout and naming with the datakit docs style (`GridFM graphkit` display name, logo-first layout)

## Test plan
- [x] Citation blocks in `docs/index.md` match `README.md` verbatim
- [x] MkDocs site renders the homepage correctly


Made with [Cursor](https://cursor.com)