### PR TITLE
ci: install only docs dependencies in deploy_docs workflow

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -6,14 +6,6 @@ on:
       - main
 permissions:
   contents: write
-# torch-scatter publishes no PyPI wheels, and its sdist imports torch at
-# build time with no build isolation, so a source build fails with
-# "No module named 'torch'". Point pip at the PyG wheel index so every job
-# installs the prebuilt wheel instead of building. (find-links under
-# [tool.uv] in pyproject.toml is honoured only by uv, not by pip.)
-env:
-  PIP_FIND_LINKS: "https://data.pyg.org/whl/torch-2.12.0+cpu.html"
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -33,5 +25,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install -e .[dev]
+      - run: pip install mkdocs-material "mkdocstrings[python]"
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -6,6 +6,14 @@ on:
       - main
 permissions:
   contents: write
+# torch-scatter publishes no PyPI wheels, and its sdist imports torch at
+# build time with no build isolation, so a source build fails with
+# "No module named 'torch'". Point pip at the PyG wheel index so every job
+# installs the prebuilt wheel instead of building. (find-links under
+# [tool.uv] in pyproject.toml is honoured only by uv, not by pip.)
+env:
+  PIP_FIND_LINKS: "https://data.pyg.org/whl/torch-2.12.0+cpu.html"
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

Fixes the documentation deployment workflow failure ([run 34163720367](https://github.com/gridfm/gridfm-graphkit/actions/runs/34163720367/job/101870531869)).

Instead of running `pip install -e .[dev]` (which installs the full root package and pulls in heavy dependencies like `torch`, `torch-scatter`, and `lightning`), install only the tools needed for MkDocs:
- `mkdocs-material`
- `mkdocstrings[python]`

This removes the need for `torch-scatter` wheels or `PIP_FIND_LINKS` entirely and significantly speeds up the workflow run.