### PR TITLE
chore(release): bump version to 0.9.0.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,9 +25,9 @@ jobs:
 
           echo "Tag detected: $TAG"
 
-          # Enforce strict format: vX.Y.Z or vX.Y.ZrcN where X,Y,Z,N are integers
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
-            echo "Invalid tag format. Expected vX.Y.Z or vX.Y.ZrcN"
+          # Enforce strict format: vX.Y.Z[.W] or vX.Y.Z[.W]rcN where X,Y,Z,W,N are integers
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(rc[0-9]+)?$ ]]; then
+            echo "Invalid tag format. Expected vX.Y.Z[.W] or vX.Y.Z[.W]rcN"
             exit 1
           fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ namespaces = false
 [project]
 name = "gridfm-graphkit"
 description = "Grid Foundation Model"
-version = "0.9.0"
+version = "0.9.0.1"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1113,7 +1113,7 @@ wheels = [
 
 [[package]]
 name = "gridfm-graphkit"
-version = "0.9.0"
+version = "0.9.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "gdown" },


### PR DESCRIPTION
### Summary

- Bump version to `0.9.0.1` in `pyproject.toml` and `uv.lock`.
- Update `.github/workflows/release.yaml` tag format validation regex to allow 4-part semantic versions (e.g. `v0.9.0.1`).